### PR TITLE
[LS-12.5] - feat(ui): add TaskList, TaskItem, planning views, all mod…

### DIFF
--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { useUIStore } from "@/store/uiStore";
+import { useNavigate } from "react-router-dom";
+import type { View } from "@/store/types";
+
+interface BottomNavProps {
+  onOpenBrowse: () => void;
+  browseActive: boolean;
+}
+
+export const BottomNav = ({ onOpenBrowse, browseActive }: BottomNavProps) => {
+  const { currentView, setView, openTaskModal } = useUIStore();
+  const navigate = useNavigate();
+
+  const isPlannerView = currentView === "planDay" || currentView === "planWeek";
+
+  const setNavView = (view: View) => setView(view);
+
+  return (
+    <>
+      <nav className="md:hidden fixed bottom-0 left-0 right-0 z-40 bg-card/95 backdrop-blur-md border-t border-border">
+        <div className="flex items-end justify-around px-2 pt-2 pb-3">
+          {/* All */}
+          <NavTab
+            label="All"
+            isActive={currentView === "all"}
+            onClick={() => setNavView("all")}
+            icon={
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+              </svg>
+            }
+          />
+
+          {/* Planner — navigates directly to Day Planner */}
+          <NavTab
+            label="Planner"
+            isActive={isPlannerView}
+            onClick={() => { setView("planDay"); navigate("/planner"); }}
+            icon={
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+              </svg>
+            }
+          />
+
+          {/* Add (center, elevated) */}
+          <button
+            onClick={() => openTaskModal()}
+            className="flex flex-col items-center -mt-5"
+            aria-label="Add task"
+          >
+            <span className="flex items-center justify-center rounded-2xl bg-gradient-to-br from-blue-500 to-blue-700 text-white shadow-lg shadow-blue-500/30 p-3.5 active:scale-95 transition-transform">
+              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
+              </svg>
+            </span>
+          </button>
+
+          {/* Calendar */}
+          <NavTab
+            label="Calendar"
+            isActive={currentView === "calendar"}
+            onClick={() => setNavView("calendar")}
+            icon={
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+              </svg>
+            }
+          />
+
+          {/* Browse */}
+          <NavTab
+            label="Browse"
+            isActive={browseActive || currentView === "category" || currentView === "completed"}
+            onClick={onOpenBrowse}
+            icon={
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h8m-8 6h16" />
+              </svg>
+            }
+          />
+        </div>
+      </nav>
+    </>
+  );
+};
+
+function NavTab({
+  label,
+  isActive,
+  onClick,
+  icon,
+}: {
+  label: string;
+  isActive: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex flex-col items-center gap-1 min-w-0 flex-1"
+      aria-label={label}
+    >
+      <span
+        className={`flex items-center justify-center w-10 h-8 rounded-xl transition-colors ${
+          isActive ? "text-primary" : "text-muted-foreground"
+        }`}
+      >
+        {icon}
+      </span>
+      <span className={`text-[10px] font-medium leading-none ${isActive ? "text-primary" : "text-muted-foreground"}`}>
+        {label}
+      </span>
+    </button>
+  );
+}

--- a/src/app/components/CalendarView.tsx
+++ b/src/app/components/CalendarView.tsx
@@ -1,0 +1,392 @@
+import { useMemo, useState } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  useDroppable,
+  useDraggable,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import { useTasksStore, type Task } from "@/store/tasksStore";
+import { useUIStore } from "@/store/uiStore";
+import { useWorkspaceStore } from "@/store/workspaceStore";
+import type { Category } from "@/store/types";
+
+// ─── Date helpers ─────────────────────────────────────────────────────────────
+function localDateStr(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/** Returns all dates within `dateStrs` on which a repeating task appears. */
+function repeatDatesInMonth(
+  task: { dueDate?: string; repeat?: string },
+  monthDateStrs: string[],
+): string[] {
+  if (!task.dueDate || !task.repeat || task.repeat === "none") return [];
+  const origin = new Date(task.dueDate + "T00:00:00");
+  const result: string[] = [];
+
+  for (const dateStr of monthDateStrs) {
+    if (dateStr === task.dueDate) continue; // already in dayTasksMap via dueDate
+    const d = new Date(dateStr + "T00:00:00");
+    if (d <= origin) continue;
+
+    let matches = false;
+    if (task.repeat === "daily") {
+      matches = true;
+    } else if (task.repeat === "weekly") {
+      const diffDays = Math.round((d.getTime() - origin.getTime()) / 86400000);
+      matches = diffDays % 7 === 0;
+    } else if (task.repeat === "monthly") {
+      matches = d.getDate() === origin.getDate();
+    }
+    if (matches) result.push(dateStr);
+  }
+  return result;
+}
+
+function getMonthGrid(year: number, month: number): (string | null)[][] {
+  const firstDay = new Date(year, month, 1);
+  const lastDay = new Date(year, month + 1, 0);
+  const startDow = (firstDay.getDay() + 6) % 7; // Monday-based
+  const totalDays = lastDay.getDate();
+
+  const cells: (string | null)[] = [
+    ...Array(startDow).fill(null),
+    ...Array.from({ length: totalDays }, (_, i) => {
+      return localDateStr(new Date(year, month, i + 1));
+    }),
+  ];
+  while (cells.length % 7 !== 0) cells.push(null);
+  const rows: (string | null)[][] = [];
+  for (let i = 0; i < cells.length; i += 7) rows.push(cells.slice(i, i + 7));
+  return rows;
+}
+
+const DOW_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+function todayStr() {
+  return localDateStr(new Date());
+}
+
+// ─── Category color helpers ───────────────────────────────────────────────────
+// Map bg-X-500 → a soft chip palette (bg + text) for calendar chips
+const BG_TO_CHIP: Record<string, { bg: string; text: string; border: string }> = {
+  "bg-blue-500":   { bg: "bg-blue-500/15",   text: "text-blue-400",   border: "border-blue-500/30" },
+  "bg-purple-500": { bg: "bg-purple-500/15", text: "text-purple-400", border: "border-purple-500/30" },
+  "bg-green-500":  { bg: "bg-green-500/15",  text: "text-green-400",  border: "border-green-500/30" },
+  "bg-amber-500":  { bg: "bg-amber-500/15",  text: "text-amber-400",  border: "border-amber-500/30" },
+  "bg-rose-500":   { bg: "bg-rose-500/15",   text: "text-rose-400",   border: "border-rose-500/30" },
+  "bg-cyan-500":   { bg: "bg-cyan-500/15",   text: "text-cyan-400",   border: "border-cyan-500/30" },
+  "bg-orange-500": { bg: "bg-orange-500/15", text: "text-orange-400", border: "border-orange-500/30" },
+  "bg-pink-500":   { bg: "bg-pink-500/15",   text: "text-pink-400",   border: "border-pink-500/30" },
+};
+
+const DEFAULT_CHIP = { bg: "bg-primary/10", text: "text-primary", border: "border-primary/20" } as const;
+
+// ─── Mini chip (draggable — supports inter-day moves) ────────────────────────
+const Chip = ({
+  task,
+  onClear,
+  categoryColor,
+}: {
+  task: Task;
+  onClear?: () => void;
+  categoryColor?: string;
+}) => {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id: task.id });
+  const palette: { bg: string; text: string; border: string } =
+    (categoryColor ? BG_TO_CHIP[categoryColor] : undefined) ?? DEFAULT_CHIP;
+  return (
+    <div
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      className={`flex items-center gap-1 text-[11px] rounded px-1.5 py-0.5 truncate max-w-full group cursor-grab active:cursor-grabbing transition-opacity border ${
+        isDragging ? "opacity-30" : ""
+      } ${palette.bg} ${palette.text} ${palette.border}`}
+    >
+      <span className="truncate flex-1">{task.text}</span>
+      {onClear && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onClear(); }}
+          className={`opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0 hover:opacity-80 hover:cursor-pointer`}
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+};
+
+// ─── DraggableTaskRow (pool) ──────────────────────────────────────────────────
+const DraggableTaskRow = ({ task }: { task: Task }) => {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id: task.id });
+  return (
+    <div
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      className={`flex items-center gap-2 px-3 py-2 rounded-lg bg-card border border-border text-sm cursor-grab active:cursor-grabbing transition-opacity ${
+        isDragging ? "opacity-30" : "hover:bg-accent"
+      }`}
+    >
+      <span className="flex-1 truncate">{task.text}</span>
+    </div>
+  );
+};
+
+// ─── CalendarCell ─────────────────────────────────────────────────────────────
+const CalendarCell = ({
+  dateStr,
+  dayNum,
+  isToday,
+  tasks,
+  onClear,
+  categories,
+}: {
+  dateStr: string;
+  dayNum: number;
+  isToday: boolean;
+  tasks: Task[];
+  onClear: (id: string) => void;
+  categories: Category[];
+}) => {
+  const { setNodeRef, isOver } = useDroppable({ id: `cal-day-${dateStr}` });
+  return (
+    <div
+      ref={setNodeRef}
+      className={`min-h-[80px] p-1.5 flex flex-col gap-0.5 transition-colors ${
+        isOver ? "bg-primary/10" : "bg-card"
+      }`}
+    >
+      <span
+        className={`text-xs font-semibold mb-0.5 self-start ${
+          isToday
+            ? "w-5 h-5 flex items-center justify-center rounded-full bg-primary text-primary-foreground"
+            : "text-muted-foreground"
+        }`}
+      >
+        {dayNum}
+      </span>
+      <div className="flex flex-col gap-0.5 overflow-hidden">
+        {tasks.slice(0, 3).map((t) => {
+          const catColor = categories.find((c) => c.name === t.category)?.color;
+          return (
+            <Chip key={t.id} task={t} onClear={() => onClear(t.id)} categoryColor={catColor} />
+          );
+        })}
+        {tasks.length > 3 && (
+          <span className="text-[10px] text-muted-foreground pl-1">+{tasks.length - 3} more</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ─── CalendarView ─────────────────────────────────────────────────────────────
+export const CalendarView = () => {
+  const { tasks: allTasks, updateTaskRich } = useTasksStore();
+  const { activeWorkspaceId, categories } = useUIStore();
+  const { workspaces } = useWorkspaceStore();
+
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const now = new Date();
+  const [viewYear, setViewYear] = useState(now.getFullYear());
+  const [viewMonth, setViewMonth] = useState(now.getMonth());
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
+  );
+
+  const monthGrid = useMemo(() => getMonthGrid(viewYear, viewMonth), [viewYear, viewMonth]);
+  const today = todayStr();
+
+  const monthLabel = new Date(viewYear, viewMonth, 1).toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+  });
+
+  const prevMonth = () => {
+    if (viewMonth === 0) { setViewYear((y) => y - 1); setViewMonth(11); }
+    else setViewMonth((m) => m - 1);
+  };
+  const nextMonth = () => {
+    if (viewMonth === 11) { setViewYear((y) => y + 1); setViewMonth(0); }
+    else setViewMonth((m) => m + 1);
+  };
+
+  const activeWorkspaceName = workspaces.find((w) => w.id === activeWorkspaceId)?.name ?? null;
+  const tasks = useMemo(
+    () => allTasks.filter((t) => !t.workspace || t.workspace === activeWorkspaceName || !activeWorkspaceName),
+    [allTasks, activeWorkspaceName],
+  );
+  const activeTasks = useMemo(
+    () => tasks.filter((t) => (t.status === "active" || t.status === "inProgress" || t.status === "overdue") && !t.isTemplate),
+    [tasks]
+  );
+
+  // All date strings in this month
+  const monthDateStrs = useMemo(
+    () => monthGrid.flat().filter(Boolean) as string[],
+    [monthGrid]
+  );
+
+  // Tasks per date — driven by dueDate + repeat
+  const dayTasksMap = useMemo(() => {
+    const map: Record<string, Task[]> = {};
+    monthDateStrs.forEach((dateStr) => { map[dateStr] = []; });
+    activeTasks.forEach((t) => {
+      if (t.dueDate && map[t.dueDate] !== undefined) {
+        map[t.dueDate].push(t);
+      }
+      // Also show on recurring dates within this month view
+      for (const rDate of repeatDatesInMonth(t, monthDateStrs)) {
+        map[rDate].push(t);
+      }
+    });
+    return map;
+  }, [activeTasks, monthDateStrs]);
+
+  // Unplanned = no dueDate (or dueDate not in this month)
+  const unplanned = useMemo(
+    () => activeTasks.filter((t) => !t.dueDate),
+    [activeTasks]
+  );
+
+  const activeTask = useMemo(
+    () => activeTasks.find((t) => t.id === activeId) ?? null,
+    [activeTasks, activeId]
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    setActiveId(null);
+    if (!over) return;
+    const overId = String(over.id);
+    if (overId.startsWith("cal-day-")) {
+      const dateStr = overId.replace("cal-day-", "");
+      const task = activeTasks.find((t) => t.id === active.id);
+      if (task) {
+        // updateTaskRich auto-computes overdue from the new dueDate
+        updateTaskRich(task.id, { dueDate: dateStr }, task.userId);
+      }
+    }
+  };
+
+  const handleClearDueDate = (id: string) => {
+    const task = activeTasks.find((t) => t.id === id);
+    if (task) {
+      // Passing dueDate:undefined auto-clears overdue in updateTaskRich
+      updateTaskRich(task.id, { dueDate: undefined }, task.userId);
+    }
+  };
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={(e) => setActiveId(e.active.id as string)}
+      onDragEnd={handleDragEnd}
+      onDragCancel={() => setActiveId(null)}
+    >
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="flex items-center gap-4">
+          <div className="flex-1">
+            <h1 className="text-2xl font-bold text-foreground">Calendar</h1>
+            <p className="text-sm text-muted-foreground mt-0.5">
+              Drag tasks onto a date to set their due date.
+            </p>
+          </div>
+          {/* Month navigator */}
+          <div className="flex items-center gap-2">
+            <button
+              onClick={prevMonth}
+              className="p-1.5 rounded-lg hover:bg-accent transition-colors text-muted-foreground hover:text-foreground"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+            </button>
+            <span className="text-sm font-semibold text-foreground min-w-[120px] text-center">{monthLabel}</span>
+            <button
+              onClick={nextMonth}
+              className="p-1.5 rounded-lg hover:bg-accent transition-colors text-muted-foreground hover:text-foreground"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* Calendar grid */}
+        <div className="bg-card border border-border rounded-2xl overflow-hidden">
+          {/* Day-of-week header */}
+          <div className="grid grid-cols-7 border-b border-border">
+            {DOW_LABELS.map((d) => (
+              <div key={d} className="py-2 text-center text-xs font-semibold text-muted-foreground">{d}</div>
+            ))}
+          </div>
+          {/* Weeks */}
+          {monthGrid.map((week, wi) => (
+            <div key={wi} className="grid grid-cols-7 gap-px bg-border">
+              {week.map((dateStr, di) =>
+                dateStr ? (
+                  <CalendarCell
+                    key={dateStr}
+                    dateStr={dateStr}
+                    dayNum={parseInt(dateStr.split("-")[2], 10)}
+                    isToday={dateStr === today}
+                    tasks={dayTasksMap[dateStr] ?? []}
+                    onClear={handleClearDueDate}
+                    categories={categories}
+                  />
+                ) : (
+                  <div key={`empty-${wi}-${di}`} className="min-h-[80px] bg-muted/20" />
+                )
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* Unplanned pool */}
+        <div>
+          <div className="flex items-center gap-2 mb-3">
+            <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+              No due date — drag to a date
+            </h2>
+            <span className="text-xs bg-muted px-2 py-0.5 rounded-full text-muted-foreground">{unplanned.length}</span>
+          </div>
+          {unplanned.length === 0 ? (
+            <div className="bg-card border border-border rounded-2xl p-8 text-center text-muted-foreground/50 text-sm">
+              All active tasks have a due date!
+            </div>
+          ) : (
+            <div className="bg-card border border-border rounded-2xl p-3 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2">
+              {unplanned.map((t) => (
+                <DraggableTaskRow key={t.id} task={t} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Drag overlay */}
+      <DragOverlay>
+        {activeTask && (
+          <div className="px-3 py-2 rounded-lg bg-card border border-primary shadow-xl text-sm font-medium opacity-90">
+            {activeTask.text}
+          </div>
+        )}
+      </DragOverlay>
+    </DndContext>
+  );
+};

--- a/src/app/components/DayPlanningView.tsx
+++ b/src/app/components/DayPlanningView.tsx
@@ -1,0 +1,339 @@
+import { useMemo } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  useDroppable,
+  useDraggable,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import { useTasksStore, type Task } from "@/store/tasksStore";
+import { useUIStore } from "@/store/uiStore";
+import { useWorkspaceStore } from "@/store/workspaceStore";
+import type { Priority } from "@/store/types";
+import { useState } from "react";
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+const TODAY = new Date();
+TODAY.setHours(0, 0, 0, 0);
+
+function localDateStr(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function todayStr() {
+  return localDateStr(TODAY);
+}
+
+function isOverdue(dateStr: string): boolean {
+  const d = new Date(dateStr);
+  d.setHours(0, 0, 0, 0);
+  return d < TODAY;
+}
+
+function dueDateLabel(dateStr?: string): string | null {
+  if (!dateStr) return null;
+  const d = new Date(dateStr);
+  d.setHours(0, 0, 0, 0);
+  if (d.getTime() === TODAY.getTime()) return "Today";
+  const diff = Math.round((d.getTime() - TODAY.getTime()) / 86400000);
+  if (diff === 1) return "Tomorrow";
+  if (diff === -1) return "Yesterday";
+  if (diff < 0) return `${Math.abs(diff)}d overdue`;
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function sortByDueDate(tasks: Task[]): Task[] {
+  return [...tasks].sort((a, b) => {
+    if (!a.dueDate && !b.dueDate) return 0;
+    if (!a.dueDate) return 1;
+    if (!b.dueDate) return -1;
+    return new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime();
+  });
+}
+
+// ─── DraggableTaskCard ────────────────────────────────────────────────────────
+interface TaskCardProps {
+  task: Task;
+  dragging?: boolean;
+  onRemove?: () => void;
+  showRemove?: boolean;
+}
+
+const TaskCard = ({ task, dragging, onRemove, showRemove }: TaskCardProps) => {
+  const label = task.title ?? task.text;
+  const due = dueDateLabel(task.dueDate);
+  const overdue = task.dueDate ? isOverdue(task.dueDate) : false;
+
+  return (
+    <div
+      className={`group flex items-start justify-between gap-2 px-3 py-2.5 rounded-xl border bg-card transition-all ${
+        dragging
+          ? "opacity-50 shadow-lg border-primary/40"
+          : "border-border hover:border-border/80 hover:shadow-sm"
+      }`}
+    >
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-foreground truncate">{label}</p>
+        <div className="flex flex-wrap items-center gap-1.5 mt-1">
+          {task.category && (
+            <span className="text-[11px] px-1.5 py-0.5 rounded-full bg-accent text-muted-foreground font-medium">
+              {task.category}
+            </span>
+          )}
+          {due && (
+            <span
+              className={`text-[11px] px-1.5 py-0.5 rounded-full font-medium ${
+                overdue
+                  ? "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400"
+                  : due === "Today"
+                  ? "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-400"
+                  : "bg-muted text-muted-foreground"
+              }`}
+            >
+              {due}
+            </span>
+          )}
+        </div>
+      </div>
+      {showRemove && onRemove && (
+        <button
+          onClick={onRemove}
+          className="opacity-0 group-hover:opacity-100 flex-shrink-0 p-1 rounded-lg hover:bg-destructive/10 hover:text-destructive text-muted-foreground transition-all cursor-pointer"
+          aria-label="Remove from today"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+};
+
+const DraggableTaskCard = ({ task }: { task: Task }) => {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id: task.id });
+  return (
+    <div
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      className="cursor-grab active:cursor-grabbing"
+    >
+      <TaskCard task={task} dragging={isDragging} />
+    </div>
+  );
+};
+
+// ─── DroppableTodayBox ────────────────────────────────────────────────────────
+interface TodayBoxProps {
+  tasks: Task[];
+  onRemove: (id: string) => void;
+}
+
+const TodayBox = ({ tasks, onRemove }: TodayBoxProps) => {
+  const { setNodeRef, isOver } = useDroppable({ id: "today-box" });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`rounded-2xl border-2 transition-colors min-h-[140px] flex flex-col ${
+        isOver
+          ? "border-primary/60 bg-primary/5"
+          : "border-border bg-card"
+      }`}
+    >
+      <div className="px-4 py-3 border-b border-border/60 flex items-center gap-2">
+        <svg className="w-4 h-4 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <h2 className="text-sm font-bold text-foreground">To do today</h2>
+        {tasks.length > 0 && (
+          <span className="ml-auto text-xs text-muted-foreground">{tasks.length} task{tasks.length !== 1 ? "s" : ""}</span>
+        )}
+      </div>
+      <div className="flex-1 p-3 space-y-2">
+        {tasks.length === 0 ? (
+          <div className={`flex flex-col items-center justify-center py-6 text-center transition-colors ${isOver ? "text-primary" : "text-muted-foreground/50"}`}>
+            <svg className="w-8 h-8 mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 4v16m8-8H4" />
+            </svg>
+            <p className="text-xs">Drag tasks here to plan your day</p>
+          </div>
+        ) : (
+          tasks.map((t) => (
+            <TaskCard key={t.id} task={t} showRemove onRemove={() => onRemove(t.id)} />
+          ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ─── PriorityBox ──────────────────────────────────────────────────────────────
+interface PriorityBoxProps {
+  title: string;
+  tasks: Task[];
+  accentClass: string;
+  dotClass: string;
+}
+
+const PriorityBox = ({ title, tasks, accentClass, dotClass }: PriorityBoxProps) => (
+  <div className="rounded-2xl border border-border bg-card flex flex-col min-h-[180px]">
+    <div className="px-4 py-3 border-b border-border/60 flex items-center gap-2">
+      <span className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${dotClass}`} />
+      <h3 className={`text-sm font-bold ${accentClass}`}>{title}</h3>
+      <span className="ml-auto text-xs text-muted-foreground">{tasks.length}</span>
+    </div>
+    <div className="flex-1 p-3 space-y-2 overflow-y-auto max-h-80">
+      {tasks.length === 0 ? (
+        <p className="text-xs text-muted-foreground/50 py-4 text-center">No tasks</p>
+      ) : (
+        tasks.map((t) => <DraggableTaskCard key={t.id} task={t} />)
+      )}
+    </div>
+  </div>
+);
+
+// ─── DayPlanningView ─────────────────────────────────────────────────────────
+export const DayPlanningView = () => {
+  const { tasks: allTasks, updateTaskRich } = useTasksStore();
+  const { activeWorkspaceId } = useUIStore();
+  const { workspaces } = useWorkspaceStore();
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
+  );
+
+  // Scope to active workspace
+  const activeWorkspaceName = workspaces.find((w) => w.id === activeWorkspaceId)?.name ?? null;
+  const tasks = useMemo(
+    () => allTasks.filter((t) => !t.workspace || t.workspace === activeWorkspaceName || !activeWorkspaceName),
+    [allTasks, activeWorkspaceName],
+  );
+
+  // Active tasks only (not completed/deleted/archived/template)
+  const activeTasks = useMemo(
+    () => tasks.filter((t) => (t.status === "active" || t.status === "inProgress") && !t.isTemplate),
+    [tasks]
+  );
+
+  // "To do today" = tasks with dueDate set to today (single source of truth)
+  // Exclude overdue tasks — they belong in the Overdue view instead
+  const todayTasks = useMemo(
+    () =>
+      activeTasks.filter(
+        (t) => (t.status === 'active' || t.status === 'inProgress') && t.dueDate === todayStr()
+      ),
+    [activeTasks]
+  );
+
+  // Priority buckets — exclude tasks already in todayTasks to avoid duplication
+  const todayIds = useMemo(() => new Set(todayTasks.map((t) => t.id)), [todayTasks]);
+
+  const buckets = useMemo(() => {
+    const rest = activeTasks.filter((t) => !todayIds.has(t.id));
+    return {
+      high:   sortByDueDate(rest.filter((t) => t.priority === "high")),
+      medium: sortByDueDate(rest.filter((t) => t.priority === "medium")),
+      low:    sortByDueDate(rest.filter((t) => t.priority === "low")),
+    };
+  }, [activeTasks, todayIds]);
+
+  const activeTask = useMemo(
+    () => activeTasks.find((t) => t.id === activeId) ?? null,
+    [activeTasks, activeId]
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    setActiveId(null);
+    if (over?.id === "today-box") {
+      const task = activeTasks.find((t) => t.id === active.id);
+      // dueDate=today is the single source of truth — this makes the task
+      // appear in Today view, Planner→Day, Week, Calendar, and MyFlow.
+      updateTaskRich(active.id as string, { dueDate: todayStr() }, task?.userId);
+    }
+  };
+
+  const handleRemoveFromToday = (id: string) => {
+    const task = activeTasks.find((t) => t.id === id);
+    // Setting dueDate to undefined removes it from all views (single source of truth).
+    updateTaskRich(id, { dueDate: undefined }, task?.userId);
+  };
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={(e) => setActiveId(e.active.id as string)}
+      onDragEnd={handleDragEnd}
+      onDragCancel={() => setActiveId(null)}
+    >
+      <div className="space-y-6">
+        {/* Title */}
+        <div className="flex items-center gap-3">
+          <div>
+            <h1 className="text-2xl font-bold text-foreground">Let's plan my day!</h1>
+            <p className="text-sm text-muted-foreground mt-0.5">
+              {new Date().toLocaleDateString("en-GB", { weekday: "long", day: "numeric", month: "long", year: "numeric" })} · Drag tasks into <span className="font-medium text-foreground">To do today</span> to build your focus list.
+            </p>
+          </div>
+        </div>
+
+        {/* Row 1: To do today */}
+        <TodayBox tasks={todayTasks} onRemove={handleRemoveFromToday} />
+
+        {/* Row 2: Priority buckets — hide empty ones */}
+        <div>
+          <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3">
+            All active tasks — drag to add to today
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            {buckets.high.length > 0 && (
+              <PriorityBox
+                title="Must have"
+                tasks={buckets.high}
+                accentClass="text-red-600 dark:text-red-400"
+                dotClass="bg-red-500"
+              />
+            )}
+            {buckets.medium.length > 0 && (
+              <PriorityBox
+                title="Should have"
+                tasks={buckets.medium}
+                accentClass="text-amber-600 dark:text-amber-400"
+                dotClass="bg-amber-500"
+              />
+            )}
+            {buckets.low.length > 0 && (
+              <PriorityBox
+                title="Nice to have"
+                tasks={buckets.low}
+                accentClass="text-green-600 dark:text-green-400"
+                dotClass="bg-green-500"
+              />
+            )}
+            {buckets.high.length === 0 && buckets.medium.length === 0 && buckets.low.length === 0 && (
+              <div className="sm:col-span-3 text-center py-6 text-sm text-muted-foreground/60">
+                All tasks are planned for today
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Drag overlay */}
+      <DragOverlay>
+        {activeTask && <TaskCard task={activeTask} />}
+      </DragOverlay>
+    </DndContext>
+  );
+};

--- a/src/app/components/MobileCategorySheet.tsx
+++ b/src/app/components/MobileCategorySheet.tsx
@@ -1,0 +1,250 @@
+import { useState } from "react";
+import { useUIStore } from "@/store/uiStore";
+import { useWorkspaceStore } from "@/store/workspaceStore";
+import { useTasksStore } from "@/store/tasksStore";
+import { useNavigate } from "react-router-dom";
+import type { View } from "@/store/types";
+
+const MAX_CATEGORIES = 6;
+
+interface MobileCategorySheetProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const VIEWS_LIST: { id: View; label: string; path: string; icon: React.ReactNode }[] = [
+  {
+    id: "all",
+    label: "All Tasks",
+    path: "/all",
+    icon: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+      </svg>
+    ),
+  },
+  {
+    id: "today",
+    label: "Today",
+    path: "/today",
+    icon: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364-6.364l-.707.707M6.343 17.657l-.707.707M17.657 17.657l-.707.707M6.343 6.343l-.707.707" />
+      </svg>
+    ),
+  },
+  {
+    id: "thisWeek",
+    label: "This Week",
+    path: "/this-week",
+    icon: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+      </svg>
+    ),
+  },
+  {
+    id: "calendar",
+    label: "Calendar",
+    path: "/calendar",
+    icon: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+      </svg>
+    ),
+  },
+  {
+    id: "completed",
+    label: "Completed",
+    path: "/completed",
+    icon: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+  },
+];
+
+export const MobileCategorySheet = ({ open, onClose }: MobileCategorySheetProps) => {
+  const {
+    currentView, currentCategory,
+    setView, setCategory,
+    categories, addCategory, removeCategory,
+    openWorkspaceModal,
+  } = useUIStore();
+  const { workspaces, activeWorkspaceId, setActiveWorkspace } = useWorkspaceStore();
+  const navigate = useNavigate();
+
+  const tasks = useTasksStore((s) => s.tasks);
+  const overdueCount = tasks.filter((t) => t.status === "overdue" && !t.isTemplate).length;
+
+  const [adding, setAdding] = useState(false);
+  const [newCatName, setNewCatName] = useState("");
+
+  if (!open) return null;
+
+  const handleAdd = () => {
+    const trimmed = newCatName.trim();
+    if (!trimmed) return;
+    addCategory(trimmed);
+    setNewCatName("");
+    setAdding(false);
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 z-40 bg-black/50" onClick={onClose} />
+      <div className="fixed bottom-0 left-0 right-0 z-50 bg-card border-t border-border rounded-t-2xl p-5 space-y-4 pb-24">
+        <div className="w-10 h-1 bg-muted rounded-full mx-auto -mt-1 mb-2" />
+        <h3 className="text-base font-bold text-foreground">Browse</h3>
+
+        {/* Workspace switcher */}
+        {workspaces.length > 0 && (
+          <div>
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider px-1 mb-2">
+              Workspace
+            </p>
+            <div className="space-y-1">
+              {workspaces.map((ws) => {
+                const isWsActive = ws.id === activeWorkspaceId;
+                return (
+                  <button
+                    key={ws.id}
+                    onClick={() => setActiveWorkspace(ws.id)}
+                    className={`flex items-center gap-3 w-full px-3 py-2.5 rounded-xl text-sm font-medium transition-colors cursor-pointer ${
+                      isWsActive ? "bg-accent text-foreground" : "text-muted-foreground hover:text-foreground hover:bg-accent/60"
+                    }`}
+                  >
+                    <span className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${ws.color}`} />
+                    <span className="flex-1 text-left truncate">{ws.name}</span>
+                    {isWsActive && (
+                      <span className="text-[10px] bg-primary/15 text-primary px-1.5 py-0.5 rounded font-semibold">Active</span>
+                    )}
+                  </button>
+                );
+              })}
+              <button
+                onClick={() => { openWorkspaceModal(); onClose(); }}
+                className="flex items-center gap-2 w-full px-3 py-2 rounded-xl text-xs text-muted-foreground hover:text-foreground hover:bg-accent/60 transition-colors cursor-pointer"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+                Manage workspaces
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Views */}
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider px-1 mb-2">
+            Views
+          </p>
+          <div className="space-y-1">
+            {VIEWS_LIST.map((view) => {
+              const isActive = currentView === view.id;
+              return (
+                <button
+                  key={view.id}
+                  onClick={() => { setView(view.id); navigate(view.path); onClose(); }}
+                  className={`flex items-center gap-3 w-full px-3 py-2.5 rounded-xl text-sm font-medium transition-colors cursor-pointer ${
+                    isActive ? "bg-accent text-foreground" : "text-muted-foreground hover:text-foreground hover:bg-accent/60"
+                  }`}
+                >
+                  {view.icon}
+                  {view.label}
+                </button>
+              );
+            })}
+            {overdueCount > 0 && (
+              <button
+                onClick={() => { setView("overdue"); navigate("/overdue"); onClose(); }}
+                className={`flex items-center gap-3 w-full px-3 py-2.5 rounded-xl text-sm font-medium transition-colors cursor-pointer ${
+                  currentView === "overdue"
+                    ? "bg-red-500/15 text-red-600 dark:text-red-400"
+                    : "text-red-500/70 hover:text-red-600 hover:bg-red-500/10"
+                }`}
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                Overdue
+                <span className="ml-auto text-xs bg-red-500 text-white rounded-full px-1.5 py-0.5 font-semibold">{overdueCount}</span>
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Categories */}
+        <div>
+          <div className="flex items-center justify-between px-1 mb-2">
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+              Categories <span className="font-normal normal-case">({categories.length}/{MAX_CATEGORIES})</span>
+            </p>
+          </div>
+          <div className="space-y-1">
+            {categories.map((cat) => {
+              const isActive = currentView === "category" && currentCategory === cat.name;
+              return (
+                <div key={cat.id} className="group flex items-center">
+                  <button
+                    onClick={() => { setCategory(cat.name); onClose(); }}
+                    className={`flex items-center gap-3 flex-1 min-w-0 px-3 py-2.5 rounded-xl text-sm font-medium transition-colors cursor-pointer ${
+                      isActive ? "bg-accent text-foreground" : "text-muted-foreground hover:text-foreground hover:bg-accent/60"
+                    }`}
+                  >
+                    <span className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${cat.color}`} />
+                    <span className="truncate">{cat.name}</span>
+                  </button>
+                  <button
+                    onClick={() => removeCategory(cat.id)}
+                    className="opacity-0 group-hover:opacity-100 p-1.5 mr-1 rounded-lg hover:bg-destructive/10 hover:text-destructive text-muted-foreground transition-all cursor-pointer"
+                    aria-label={`Remove ${cat.name}`}
+                  >
+                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Add category */}
+          {adding ? (
+            <div className="mt-2 space-y-2">
+              <input
+                autoFocus
+                type="text"
+                value={newCatName}
+                onChange={(e) => setNewCatName(e.target.value)}
+                onKeyDown={(e) => { if (e.key === "Enter") handleAdd(); if (e.key === "Escape") { setAdding(false); setNewCatName(""); } }}
+                placeholder="Category name…"
+                maxLength={20}
+                className="w-full px-3 py-2 text-sm rounded-xl border border-border bg-background focus:outline-none focus:ring-2 focus:ring-primary/30"
+              />
+              <div className="flex gap-2">
+                <button onClick={handleAdd} disabled={!newCatName.trim()} className="flex-1 py-2 text-sm font-medium rounded-xl bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-40 cursor-pointer">Add</button>
+                <button onClick={() => { setAdding(false); setNewCatName(""); }} className="flex-1 py-2 text-sm font-medium rounded-xl border border-border hover:bg-accent cursor-pointer">Cancel</button>
+              </div>
+            </div>
+          ) : (
+            categories.length < MAX_CATEGORIES && (
+              <button
+                onClick={() => setAdding(true)}
+                className="flex items-center gap-2 w-full mt-1 px-3 py-2.5 rounded-xl text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-accent transition-colors cursor-pointer"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
+                </svg>
+                Add Category
+              </button>
+            )
+          )}
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/app/components/MonthPlanningView.tsx
+++ b/src/app/components/MonthPlanningView.tsx
@@ -1,0 +1,341 @@
+import { useMemo, useState } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  useDroppable,
+  useDraggable,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import { useTasksStore, type Task } from "@/store/tasksStore";
+import { useUIStore } from "@/store/uiStore";
+import { useWorkspaceStore } from "@/store/workspaceStore";
+
+// ─── Date helpers ─────────────────────────────────────────────────────────────
+function localDateStr(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function getMonthGrid(year: number, month: number): (string | null)[][] {
+  const firstDay = new Date(year, month, 1);
+  const lastDay = new Date(year, month + 1, 0);
+  const startDow = (firstDay.getDay() + 6) % 7; // Monday-based (0=Mon)
+  const totalDays = lastDay.getDate();
+
+  const cells: (string | null)[] = [
+    ...Array(startDow).fill(null),
+    ...Array.from({ length: totalDays }, (_, i) => {
+      return localDateStr(new Date(year, month, i + 1));
+    }),
+  ];
+  // pad to full weeks
+  while (cells.length % 7 !== 0) cells.push(null);
+  // split into rows
+  const rows: (string | null)[][] = [];
+  for (let i = 0; i < cells.length; i += 7) rows.push(cells.slice(i, i + 7));
+  return rows;
+}
+
+const DOW_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+function todayStr() {
+  return localDateStr(new Date());
+}
+
+// ─── Mini chip ────────────────────────────────────────────────────────────────
+const Chip = ({
+  task,
+  onRemove,
+}: {
+  task: Task;
+  onRemove?: () => void;
+}) => (
+  <div className="group flex items-center gap-1 px-1.5 py-0.5 rounded bg-primary/10 text-primary text-[10px] font-medium overflow-hidden">
+    {task.priority && (
+      <span
+        className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${
+          task.priority === "high" ? "bg-red-500" : task.priority === "medium" ? "bg-amber-500" : "bg-green-500"
+        }`}
+      />
+    )}
+    <span className="truncate flex-1">{task.title ?? task.text}</span>
+    {onRemove && (
+      <button
+        onClick={onRemove}
+        className="opacity-0 group-hover:opacity-100 flex-shrink-0 hover:text-destructive transition-all"
+        aria-label="Remove"
+      >
+        ×
+      </button>
+    )}
+  </div>
+);
+
+// ─── Draggable pool card ──────────────────────────────────────────────────────
+const DraggablePoolCard = ({ task }: { task: Task }) => {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id: task.id });
+  return (
+    <div ref={setNodeRef} {...listeners} {...attributes} className="cursor-grab active:cursor-grabbing">
+      <div
+        className={`flex items-center gap-2 px-3 py-2 rounded-xl border bg-card text-sm transition-all ${
+          isDragging ? "opacity-40 border-primary/40 shadow-lg" : "border-border hover:border-border/80"
+        }`}
+      >
+        {task.priority && (
+          <span
+            className={`w-2 h-2 rounded-full flex-shrink-0 ${
+              task.priority === "high" ? "bg-red-500" : task.priority === "medium" ? "bg-amber-500" : "bg-green-500"
+            }`}
+          />
+        )}
+        <span className="flex-1 truncate font-medium text-foreground">{task.title ?? task.text}</span>
+        {task.category && (
+          <span className="text-[11px] px-1.5 py-0.5 rounded-full bg-accent text-muted-foreground">{task.category}</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ─── Droppable calendar cell ──────────────────────────────────────────────────
+interface CalendarCellProps {
+  dateStr: string;
+  dayNum: number;
+  isToday: boolean;
+  tasks: Task[];
+  onRemove: (id: string) => void;
+}
+
+const CalendarCell = ({ dateStr, dayNum, isToday, tasks, onRemove }: CalendarCellProps) => {
+  const { setNodeRef, isOver } = useDroppable({ id: `month-day-${dateStr}` });
+  return (
+    <div
+      ref={setNodeRef}
+      className={`min-h-[80px] p-1.5 rounded-xl border-2 flex flex-col gap-1 transition-colors ${
+        isOver
+          ? "border-primary/60 bg-primary/5"
+          : isToday
+          ? "border-primary/40 bg-primary/5"
+          : "border-border bg-card/40"
+      }`}
+    >
+      <span
+        className={`text-xs font-semibold leading-none ${
+          isToday
+            ? "w-5 h-5 flex items-center justify-center rounded-full bg-primary text-primary-foreground"
+            : "text-muted-foreground"
+        }`}
+      >
+        {dayNum}
+      </span>
+      <div className="flex flex-col gap-0.5 overflow-hidden">
+        {tasks.slice(0, 3).map((t) => (
+          <Chip key={t.id} task={t} onRemove={() => onRemove(t.id)} />
+        ))}
+        {tasks.length > 3 && (
+          <span className="text-[10px] text-muted-foreground pl-1">+{tasks.length - 3} more</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ─── MonthPlanningView ────────────────────────────────────────────────────────
+export const MonthPlanningView = () => {
+  const { tasks: allTasks, updateTaskRich } = useTasksStore();
+  const { activeWorkspaceId } = useUIStore();
+  const { workspaces } = useWorkspaceStore();
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  const now = new Date();
+  const [viewYear, setViewYear] = useState(now.getFullYear());
+  const [viewMonth, setViewMonth] = useState(now.getMonth());
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
+  );
+
+  const monthGrid = useMemo(() => getMonthGrid(viewYear, viewMonth), [viewYear, viewMonth]);
+  const today = todayStr();
+
+  const monthLabel = new Date(viewYear, viewMonth, 1).toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+  });
+
+  const prevMonth = () => {
+    if (viewMonth === 0) { setViewYear((y) => y - 1); setViewMonth(11); }
+    else setViewMonth((m) => m - 1);
+  };
+  const nextMonth = () => {
+    if (viewMonth === 11) { setViewYear((y) => y + 1); setViewMonth(0); }
+    else setViewMonth((m) => m + 1);
+  };
+
+  const activeWorkspaceName = workspaces.find((w) => w.id === activeWorkspaceId)?.name ?? null;
+  const tasks = useMemo(
+    () => allTasks.filter((t) => !t.workspace || t.workspace === activeWorkspaceName || !activeWorkspaceName),
+    [allTasks, activeWorkspaceName],
+  );
+  const activeTasks = useMemo(
+    () => tasks.filter((t) => (t.status === "active" || t.status === "inProgress") && !t.isTemplate),
+    [tasks]
+  );
+
+  // All date strings in this month
+  const monthDateStrs = useMemo(
+    () => monthGrid.flat().filter(Boolean) as string[],
+    [monthGrid]
+  );
+
+  // Tasks per date — driven by dueDate (single source of truth)
+  const dayTasksMap = useMemo(() => {
+    const map: Record<string, Task[]> = {};
+    monthDateStrs.forEach((dateStr) => {
+      map[dateStr] = activeTasks.filter((t) => t.dueDate === dateStr);
+    });
+    return map;
+  }, [activeTasks, monthDateStrs]);
+
+  // Unplanned tasks (no dueDate, or dueDate not in this month)
+  const plannedInMonthIds = useMemo(() => {
+    const ids = new Set<string>();
+    monthDateStrs.forEach((dateStr) => {
+      activeTasks.forEach((t) => { if (t.dueDate === dateStr) ids.add(t.id); });
+    });
+    return ids;
+  }, [activeTasks, monthDateStrs]);
+
+  const unplanned = useMemo(
+    () => activeTasks.filter((t) => !plannedInMonthIds.has(t.id)),
+    [activeTasks, plannedInMonthIds]
+  );
+
+  const activeTask = useMemo(
+    () => activeTasks.find((t) => t.id === activeId) ?? null,
+    [activeTasks, activeId]
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    setActiveId(null);
+    if (!over) return;
+    const overId = String(over.id);
+    if (overId.startsWith("month-day-")) {
+      const dateStr = overId.replace("month-day-", "");
+      const task = activeTasks.find((t) => t.id === active.id);
+      if (!task || task.dueDate === dateStr) return;
+      // dueDate is the single source of truth.
+      updateTaskRich(active.id as string, { dueDate: dateStr }, task.userId);
+    }
+  };
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={(e) => setActiveId(e.active.id as string)}
+      onDragEnd={handleDragEnd}
+      onDragCancel={() => setActiveId(null)}
+    >
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="flex items-center gap-4">
+          <div className="flex-1">
+            <h1 className="text-2xl font-bold text-foreground">Let's plan the month!</h1>
+            <p className="text-sm text-muted-foreground mt-0.5">
+              Drag tasks onto calendar dates to schedule them.
+            </p>
+          </div>
+          {/* Month navigator */}
+          <div className="flex items-center gap-2">
+            <button
+              onClick={prevMonth}
+              className="p-1.5 rounded-lg hover:bg-accent transition-colors text-muted-foreground hover:text-foreground"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+            </button>
+            <span className="text-sm font-semibold text-foreground min-w-[120px] text-center">{monthLabel}</span>
+            <button
+              onClick={nextMonth}
+              className="p-1.5 rounded-lg hover:bg-accent transition-colors text-muted-foreground hover:text-foreground"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* Calendar grid */}
+        <div className="bg-card border border-border rounded-2xl overflow-hidden">
+          {/* Day-of-week header */}
+          <div className="grid grid-cols-7 border-b border-border">
+            {DOW_LABELS.map((d) => (
+              <div key={d} className="py-2 text-center text-xs font-semibold text-muted-foreground">{d}</div>
+            ))}
+          </div>
+          {/* Weeks */}
+          {monthGrid.map((week, wi) => (
+            <div key={wi} className="grid grid-cols-7 gap-px bg-border">
+              {week.map((dateStr, di) =>
+                dateStr ? (
+                  <CalendarCell
+                    key={dateStr}
+                    dateStr={dateStr}
+                    dayNum={parseInt(dateStr.split("-")[2], 10)}
+                    isToday={dateStr === today}
+                    tasks={dayTasksMap[dateStr] ?? []}
+                    onRemove={(id) => {
+                      const task = activeTasks.find((t) => t.id === id);
+                      updateTaskRich(id, { dueDate: undefined }, task?.userId);
+                    }}
+                  />
+                ) : (
+                  <div key={`empty-${wi}-${di}`} className="min-h-[80px] bg-muted/20" />
+                )
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* Unplanned pool */}
+        <div>
+          <div className="flex items-center gap-2 mb-3">
+            <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+              Unplanned tasks — drag to a date
+            </h2>
+            <span className="text-xs bg-muted px-2 py-0.5 rounded-full text-muted-foreground">{unplanned.length}</span>
+          </div>
+          {unplanned.length === 0 ? (
+            <div className="bg-card border border-border rounded-2xl p-8 text-center text-muted-foreground/50 text-sm">
+              All active tasks are planned for this month!
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+              {unplanned.map((t) => (
+                <DraggablePoolCard key={t.id} task={t} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <DragOverlay>
+        {activeTask && (
+          <div className="px-3 py-2 rounded-xl border bg-card shadow-xl text-sm font-medium text-foreground">
+            {activeTask.title ?? activeTask.text}
+          </div>
+        )}
+      </DragOverlay>
+    </DndContext>
+  );
+};

--- a/src/app/components/Notifications.tsx
+++ b/src/app/components/Notifications.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from "react";
+import { useUIStore } from "@/store/uiStore";
+import type { AppNotification } from "@/store/types";
+
+export const Notifications = () => {
+  const { notifications } = useUIStore();
+
+  return (
+    <div className="fixed bottom-6 right-4 md:right-6 space-y-2 z-[60] pointer-events-none">
+      {notifications.map((n) => (
+        <NotificationToast key={n.id} notification={n} />
+      ))}
+    </div>
+  );
+};
+
+const TYPE_STYLES: Record<AppNotification["type"], string> = {
+  success: "bg-green-600 border-green-500/50",
+  error: "bg-red-600 border-red-500/50",
+  warning: "bg-yellow-600 border-yellow-500/50",
+  info: "bg-blue-600 border-blue-500/50",
+};
+
+function NotificationToast({ notification }: { notification: AppNotification }) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (el) {
+      el.style.animation = "fadeInUp 0.3s ease forwards";
+    }
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      className={`pointer-events-auto ${TYPE_STYLES[notification.type]} text-white px-4 py-3 rounded-xl shadow-lg border max-w-xs opacity-0`}
+    >
+      <p className="font-semibold text-sm">{notification.title}</p>
+      {notification.body && (
+        <p className="text-xs mt-0.5 opacity-90">{notification.body}</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/components/PlannerShell.tsx
+++ b/src/app/components/PlannerShell.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { DayPlanningView } from "./DayPlanningView";
+import { WeekPlanningView } from "./WeekPlanningView";
+
+type PlannerTab = "day" | "week";
+
+const TABS: { id: PlannerTab; label: string; }[] = [
+  { id: "day",  label: "Day"},
+  { id: "week", label: "Week"},
+];
+
+interface PlannerShellProps {
+  /** Optionally open to a specific tab (e.g. "week") */
+  initialTab?: PlannerTab;
+}
+
+export const PlannerShell = ({ initialTab = "day" }: PlannerShellProps) => {
+  const [tab, setTab] = useState<PlannerTab>(initialTab);
+
+  return (
+    <div className="space-y-6">
+      {/* Tab bar */}
+      <div className="flex items-center gap-1 bg-muted rounded-xl p-1 w-fit">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            onClick={() => setTab(t.id)}
+            className={`flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-semibold transition-all hover:cursor-pointer ${
+              tab === t.id
+                ? "bg-card text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Content */}
+      {tab === "day"  && <DayPlanningView />}
+      {tab === "week" && <WeekPlanningView />}
+    </div>
+  );
+};

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -1,0 +1,575 @@
+import { useState, useMemo } from "react";
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+
+import { useUIStore } from "@/store/uiStore";
+import { useTasksStore } from "@/store/tasksStore";
+import { useWorkspaceStore } from "@/store/workspaceStore";
+import { RenameModal } from "./modals/RenameModal";
+import type { Category, View } from "@/store/types";
+
+const MAX_CATEGORIES = 6;
+const TAGS_GRID_COLS = 3;
+const TAGS_MAX_ROWS = 3;
+
+// ─── SortableCategoryItem ─────────────────────────────────────────────────────
+interface SortableCatProps {
+  cat: Category;
+  isActive: boolean;
+  onClick: () => void;
+  onDoubleClick: () => void;
+  onRemove: () => void;
+}
+
+const SortableCategoryItem = ({ cat, isActive, onClick, onDoubleClick, onRemove }: SortableCatProps) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: cat.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className="flex items-center gap-1 group/cat">
+      <button
+        {...attributes}
+        {...listeners}
+        className="p-1 opacity-0 group-hover/cat:opacity-40 hover:!opacity-100 text-muted-foreground cursor-grab active:cursor-grabbing transition-opacity"
+        tabIndex={-1}
+        aria-label="Drag to reorder"
+      >
+        <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24">
+          <circle cx="9" cy="6" r="1.5" /><circle cx="15" cy="6" r="1.5" />
+          <circle cx="9" cy="12" r="1.5" /><circle cx="15" cy="12" r="1.5" />
+          <circle cx="9" cy="18" r="1.5" /><circle cx="15" cy="18" r="1.5" />
+        </svg>
+      </button>
+      <button
+        onClick={onClick}
+        onDoubleClick={onDoubleClick}
+        title="Double-click to rename"
+        className={`flex items-center gap-2.5 flex-1 min-w-0 px-3 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
+          isActive
+            ? "bg-accent text-foreground"
+            : "text-muted-foreground hover:text-foreground hover:bg-accent/60"
+        }`}
+      >
+        <span className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${cat.color}`} />
+        <span className="truncate">{cat.name}</span>
+      </button>
+      <button
+        onClick={onRemove}
+        className="opacity-0 group-hover/cat:opacity-100 p-1 mr-0.5 rounded hover:bg-destructive/10 hover:text-destructive text-muted-foreground transition-all cursor-pointer"
+        aria-label={`Remove ${cat.name}`}
+        title="Remove category"
+      >
+        <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  );
+};
+
+// ─── SeeAllTagsModal ───────────────────────────────────────────────────────────
+interface TagEntry { tag: string; count: number }
+interface SeeAllTagsModalProps {
+  tagCounts: Map<string, number>;
+  activeTag: string | null;
+  onSelect: (tag: string) => void;
+  onClose: () => void;
+}
+
+const SeeAllTagsModal = ({ tagCounts, activeTag, onSelect, onClose }: SeeAllTagsModalProps) => {
+  const sorted = useMemo(() => {
+    const entries: TagEntry[] = Array.from(tagCounts.entries())
+      .map(([tag, count]) => ({ tag, count }))
+      .sort((a, b) => a.tag.localeCompare(b.tag));
+    const groups: Record<string, TagEntry[]> = {};
+    for (const entry of entries) {
+      const letter = entry.tag[0]?.toUpperCase() ?? "#";
+      if (!groups[letter]) groups[letter] = [];
+      groups[letter].push(entry);
+    }
+    return groups;
+  }, [tagCounts]);
+
+  return (
+    <div className="fixed inset-0 z-[200] flex items-center justify-center" onClick={onClose}>
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" />
+      <div
+        className="relative z-10 w-[400px] max-h-[80vh] flex flex-col rounded-2xl border border-border bg-background shadow-2xl overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-5 py-4 border-b border-border/50">
+          <h3 className="text-base font-semibold text-foreground">All Tags</h3>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <div className="overflow-y-auto flex-1 px-5 py-4 space-y-5">
+          {Object.entries(sorted).map(([letter, entries]) => (
+            <div key={letter}>
+              <p className="text-[11px] font-bold text-muted-foreground uppercase tracking-widest mb-2">
+                {letter} <span className="font-normal normal-case">({entries.length})</span>
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {entries.map(({ tag, count }) => (
+                  <button
+                    key={tag}
+                    onClick={() => { onSelect(tag); onClose(); }}
+                    className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-colors cursor-pointer ${
+                      activeTag === tag
+                        ? "bg-primary text-primary-foreground"
+                        : "bg-accent text-foreground hover:bg-accent/80"
+                    }`}
+                  >
+                    <span className="opacity-60">#</span>{tag}
+                    <span className="opacity-60 text-[10px]">{count}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ─── VIEWS ────────────────────────────────────────────────────────────────────
+const VIEWS: { id: View; label: string; icon: React.ReactNode }[] = [
+  {
+    id: "all",
+    label: "All Tasks",
+    icon: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+      </svg>
+    ),
+  },
+  {
+    id: "today",
+    label: "Today",
+    icon: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+      </svg>
+    ),
+  },
+  {
+    id: "completed",
+    label: "Completed",
+    icon: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+  },
+  {
+    id: "thisWeek",
+    label: "This Week",
+    icon: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+      </svg>
+    ),
+  },
+  {
+    id: "calendar",
+    label: "Calendar",
+    icon: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+      </svg>
+    ),
+  },
+];
+
+// ─── Sidebar ──────────────────────────────────────────────────────────────────
+export const Sidebar = () => {
+  const {
+    currentView, currentCategory,
+    setView, setCategory,
+    openTaskModal,
+    categories, addCategory, removeCategory, renameCategory, reorderCategories,
+    activeWorkspaceId,
+  } = useUIStore();
+
+  const allTasks = useTasksStore((s) => s.tasks);
+  const { workspaces } = useWorkspaceStore();
+
+  // Scope tasks to active workspace
+  const activeWorkspaceName = workspaces.find((w) => w.id === activeWorkspaceId)?.name ?? null;
+  const tasks = useMemo(
+    () => allTasks.filter((t) => !t.workspace || t.workspace === activeWorkspaceName || !activeWorkspaceName),
+    [allTasks, activeWorkspaceName],
+  );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } })
+  );
+
+  const [renameTarget, setRenameTarget] = useState<{
+    kind: "category";
+    id: string;
+    name: string;
+    color: string;
+  } | null>(null);
+
+  const [adding, setAdding] = useState(false);
+  const [newCatName, setNewCatName] = useState("");
+  const [activeTag, setActiveTag] = useState<string | null>(null);
+  const [showAllTags, setShowAllTags] = useState(false);
+
+  // ── Collapsible sections (persisted)
+  const loadCollapsed = (): Record<string, boolean> => {
+    try { return JSON.parse(localStorage.getItem("doitly_sidebar_collapsed") ?? "{}"); } catch { return {}; }
+  };
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>(loadCollapsed);
+  const toggleSection = (key: string) => {
+    setCollapsed((prev) => {
+      const next = { ...prev, [key]: !prev[key] };
+      localStorage.setItem("doitly_sidebar_collapsed", JSON.stringify(next));
+      return next;
+    });
+  };
+
+  const overdueCount = useMemo(
+    () => tasks.filter((t) => t.status === "overdue" && !t.isTemplate).length,
+    [tasks]
+  );
+
+  const tagCounts = useMemo<Map<string, number>>(() => {
+    const map = new Map<string, number>();
+    for (const t of tasks) {
+      if (t.isTemplate) continue;
+      if (t.status === "deleted" || t.status === "archived") continue;
+      for (const tag of t.tags ?? []) {
+        const trimmed = tag.trim();
+        if (trimmed) map.set(trimmed, (map.get(trimmed) ?? 0) + 1);
+      }
+    }
+    return map;
+  }, [tasks]);
+
+  const sortedTags = useMemo(
+    () => Array.from(tagCounts.entries()).sort((a, b) => a[0].localeCompare(b[0])),
+    [tagCounts]
+  );
+  const maxVisible = TAGS_GRID_COLS * TAGS_MAX_ROWS;
+  const visibleTags = sortedTags.slice(0, maxVisible);
+  const hiddenCount = sortedTags.length - visibleTags.length;
+
+  const handleAddCategory = () => {
+    const trimmed = newCatName.trim();
+    if (!trimmed) return;
+    addCategory(trimmed);
+    setNewCatName("");
+    setAdding(false);
+  };
+
+  const handleCatDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIdx = categories.findIndex((c) => c.id === active.id);
+    const newIdx = categories.findIndex((c) => c.id === over.id);
+    reorderCategories(arrayMove(categories, oldIdx, newIdx));
+  };
+
+  const handleTagClick = (tag: string) => {
+    if (activeTag === tag) {
+      setActiveTag(null);
+      setView("all");
+    } else {
+      setActiveTag(tag);
+      setCategory(`#${tag}`);
+    }
+  };
+
+  return (
+    <>
+      <aside
+        className="hidden md:flex flex-col w-64 shrink-0 border-r border-border/50 bg-background/50 pt-4 pb-6 px-3 gap-2 overflow-y-auto"
+        aria-label="Main navigation"
+      >
+
+        {/* Add Task */}
+        <button
+          onClick={() => openTaskModal()}
+          aria-label="Add new task"
+          className="flex items-center justify-center gap-2 w-full px-4 py-2.5 rounded-xl font-semibold text-sm bg-gradient-to-r from-blue-600 to-blue-700 text-white hover:shadow-lg hover:shadow-blue-500/20 transition-all duration-200 cursor-pointer"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
+          </svg>
+          Add Task
+        </button>
+
+        {/* Planner button */}
+        <button
+          onClick={() => setView("planDay" as View)}
+          className={`flex items-center gap-2 w-full px-4 py-2.5 rounded-xl font-semibold text-sm transition-all duration-200 cursor-pointer ${
+            currentView === "planDay" || currentView === "planWeek"
+              ? "bg-gradient-to-r from-violet-500 to-purple-600 text-white shadow-lg shadow-purple-500/20"
+              : "bg-gradient-to-r from-violet-500/80 to-purple-600/80 text-white hover:shadow-lg hover:shadow-purple-500/20"
+          }`}
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+          Planner
+        </button>
+
+        {/* VIEWS */}
+        <div className="space-y-0.5">
+          <button
+            onClick={() => toggleSection("views")}
+            className="flex items-center justify-between w-full px-2 py-1 group cursor-pointer"
+          >
+            <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider group-hover:text-foreground transition-colors">Views</p>
+            <svg
+              className={`w-3 h-3 text-muted-foreground transition-transform duration-200 ${collapsed["views"] ? "-rotate-90" : ""}`}
+              fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          {!collapsed["views"] && VIEWS.map((view) => {
+            const isActive = currentView === view.id && currentView !== "category";
+            return (
+              <button
+                key={view.id}
+                onClick={() => setView(view.id)}
+                aria-label={`Go to ${view.label} view`}
+                aria-current={isActive ? "page" : undefined}
+                className={`flex items-center gap-3 w-full px-3 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
+                  isActive
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:text-foreground hover:bg-accent/60"
+                }`}
+              >
+                {view.icon}
+                {view.label}
+              </button>
+            );
+          })}
+          {!collapsed["views"] && overdueCount > 0 && (
+            <button
+              onClick={() => setView("overdue" as View)}
+              aria-label="Go to Overdue view"
+              aria-current={currentView === "overdue" ? "page" : undefined}
+              className={`flex items-center gap-3 w-full px-3 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
+                currentView === "overdue"
+                  ? "bg-red-500/15 text-red-600 dark:text-red-400"
+                  : "text-red-500/70 hover:text-red-600 hover:bg-red-500/10"
+              }`}
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              Overdue
+              {overdueCount > 0 && (
+                <span className="ml-auto text-xs bg-red-500 text-white rounded-full px-1.5 py-0.5 font-semibold">{overdueCount}</span>
+              )}
+            </button>
+          )}
+        </div>
+
+        {/* CATEGORIES */}
+        <div className="space-y-0.5 mt-3">
+          <button
+            onClick={() => toggleSection("categories")}
+            className="flex items-center justify-between w-full px-2 py-1 group cursor-pointer"
+          >
+            <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider group-hover:text-foreground transition-colors">
+              Categories
+              <span className="ml-1.5 font-normal normal-case">({categories.length}/{MAX_CATEGORIES})</span>
+            </p>
+            <svg
+              className={`w-3 h-3 text-muted-foreground transition-transform duration-200 ${collapsed["categories"] ? "-rotate-90" : ""}`}
+              fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+
+          {!collapsed["categories"] && (
+            <>
+            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleCatDragEnd}>
+              <SortableContext items={categories.map((c) => c.id)} strategy={verticalListSortingStrategy}>
+                <div className="space-y-0.5">
+                  {categories.map((cat) => {
+                    const isActive = currentView === "category" && currentCategory === cat.name;
+                    return (
+                      <SortableCategoryItem
+                        key={cat.id}
+                        cat={cat}
+                        isActive={isActive}
+                        onClick={() => setCategory(cat.name)}
+                        onDoubleClick={() =>
+                          setRenameTarget({ kind: "category", id: cat.id, name: cat.name, color: cat.color })
+                        }
+                        onRemove={() => removeCategory(cat.id)}
+                      />
+                    );
+                  })}
+                </div>
+              </SortableContext>
+            </DndContext>
+
+            {adding ? (
+              <div className="px-2 pt-1 space-y-1.5">
+                <input
+                  autoFocus
+                  type="text"
+                  value={newCatName}
+                  onChange={(e) => setNewCatName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleAddCategory();
+                    if (e.key === "Escape") { setAdding(false); setNewCatName(""); }
+                  }}
+                  placeholder="Category name…"
+                  maxLength={20}
+                  className="w-full px-2.5 py-1.5 text-sm rounded-lg border border-border bg-background focus:outline-none focus:ring-2 focus:ring-primary/30"
+                />
+                <div className="flex gap-1.5">
+                  <button
+                    onClick={handleAddCategory}
+                    disabled={!newCatName.trim()}
+                    className="flex-1 py-1 text-xs font-medium rounded-lg bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-40 cursor-pointer"
+                  >Add</button>
+                  <button
+                    onClick={() => { setAdding(false); setNewCatName(""); }}
+                    className="flex-1 py-1 text-xs font-medium rounded-lg border border-border hover:bg-accent cursor-pointer"
+                  >Cancel</button>
+                </div>
+              </div>
+            ) : (
+              categories.length < MAX_CATEGORIES && (
+                <button
+                  onClick={() => setAdding(true)}
+                  className="flex items-center gap-2 w-full px-3 py-2 rounded-lg text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-accent transition-colors cursor-pointer"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
+                  </svg>
+                  Add Category
+                </button>
+              )
+            )}
+            </>
+          )}
+        </div>
+
+        {/* TAGS */}
+        {sortedTags.length > 0 && (
+          <div className="mt-3">
+            <div className="flex items-center justify-between px-2 py-1">
+              <button
+                onClick={() => toggleSection("tags")}
+                className="flex items-center gap-1 group cursor-pointer w-full justify-between"
+              >
+                <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider group-hover:text-foreground transition-colors">
+                  Tags
+                  <span className="ml-1.5 font-normal normal-case">({sortedTags.length})</span>
+                </p>
+                <svg
+                  className={`w-3 h-3 text-muted-foreground transition-transform duration-200 ml-1 ${collapsed["tags"] ? "-rotate-90" : ""}`}
+                  fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+              {activeTag && (
+                <button
+                  onClick={() => { setActiveTag(null); setView("all"); }}
+                  className="text-[10px] text-primary hover:opacity-80 cursor-pointer"
+                >Clear</button>
+              )}
+            </div>
+
+            {!collapsed["tags"] && (
+            <>
+            <div
+              className="grid gap-1 px-1"
+              style={{ gridTemplateColumns: `repeat(${TAGS_GRID_COLS}, minmax(0, 1fr))` }}
+            >
+              {visibleTags.map(([tag, count]) => (
+                <button
+                  key={tag}
+                  onClick={() => handleTagClick(tag)}
+                  title={`${tag} (${count})`}
+                  className={`flex items-center gap-0.5 px-2 py-1.5 rounded-lg text-xs font-medium truncate transition-colors cursor-pointer ${
+                    activeTag === tag
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-accent/60 text-muted-foreground hover:bg-accent hover:text-foreground"
+                  }`}
+                >
+                  <span className="opacity-60">#</span>
+                  <span className="truncate">{tag}</span>
+                </button>
+              ))}
+            </div>
+
+            {hiddenCount > 0 && (
+              <button
+                onClick={() => setShowAllTags(true)}
+                className="flex items-center gap-1.5 w-full px-3 py-1.5 mt-1 rounded-lg text-xs text-muted-foreground hover:text-foreground hover:bg-accent/60 transition-colors cursor-pointer"
+              >
+                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 10h16M4 14h7" />
+                </svg>
+                See all tags (+{hiddenCount} more)
+              </button>
+            )}
+            </>
+            )}
+          </div>
+        )}
+      </aside>
+
+      {renameTarget && (
+        <RenameModal
+          open={!!renameTarget}
+          title="Rename Category"
+          initialName={renameTarget.name}
+          initialColor={renameTarget.color}
+          onSave={(name, color) => {
+            renameCategory(renameTarget.id, name, color);
+          }}
+          onClose={() => setRenameTarget(null)}
+        />
+      )}
+
+      {showAllTags && (
+        <SeeAllTagsModal
+          tagCounts={tagCounts}
+          activeTag={activeTag}
+          onSelect={handleTagClick}
+          onClose={() => setShowAllTags(false)}
+        />
+      )}
+    </>
+  );
+};

--- a/src/app/components/WeekPlanningView.tsx
+++ b/src/app/components/WeekPlanningView.tsx
@@ -1,0 +1,314 @@
+import { useMemo, useState } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  useDroppable,
+  useDraggable,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import { useTasksStore, getISOWeekString, type Task } from "@/store/tasksStore";
+import { useUIStore } from "@/store/uiStore";
+import { useWorkspaceStore } from "@/store/workspaceStore";
+
+// ─── Date helpers ─────────────────────────────────────────────────────────────
+function localDateStr(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function getWeekDays(): { dateStr: string; label: string; shortLabel: string; isToday: boolean }[] {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  // Monday of current week
+  const mon = new Date(today);
+  const day = mon.getDay(); // 0=Sun, 1=Mon…
+  mon.setDate(mon.getDate() - ((day + 6) % 7));
+
+  return Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(mon);
+    d.setDate(mon.getDate() + i);
+    const dateStr = localDateStr(d);
+    const isToday = d.getTime() === today.getTime();
+    return {
+      dateStr,
+      label: d.toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" }),
+      shortLabel: d.toLocaleDateString("en-US", { weekday: "short", day: "numeric" }),
+      isToday,
+    };
+  });
+}
+
+// ─── Shared mini task card ────────────────────────────────────────────────────
+interface MiniCardProps {
+  task: Task;
+  dragging?: boolean;
+  onRemove?: () => void;
+}
+
+const MiniCard = ({ task, dragging, onRemove }: MiniCardProps) => (
+  <div
+    className={`group flex items-center gap-1.5 px-2 py-1.5 rounded-lg border bg-card text-xs transition-all ${
+      dragging ? "opacity-40 shadow-lg border-primary/40" : "border-border hover:border-border/80"
+    }`}
+  >
+    {task.priority && (
+      <span
+        className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${
+          task.priority === "high" ? "bg-red-500" : task.priority === "medium" ? "bg-amber-500" : "bg-green-500"
+        }`}
+      />
+    )}
+    <span className="truncate text-foreground font-medium flex-1">{task.title ?? task.text}</span>
+    {onRemove && (
+      <button
+        onClick={onRemove}
+        className="opacity-0 group-hover:opacity-100 flex-shrink-0 p-0.5 rounded hover:bg-destructive/10 hover:text-destructive text-muted-foreground transition-all cursor-pointer"
+        aria-label="Remove"
+      >
+        <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    )}
+  </div>
+);
+
+const DraggableMiniCard = ({ task, onRemove }: { task: Task; onRemove?: () => void }) => {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id: task.id });
+  return (
+    <div ref={setNodeRef} {...listeners} {...attributes} className="cursor-grab active:cursor-grabbing">
+      <MiniCard task={task} dragging={isDragging} onRemove={onRemove} />
+    </div>
+  );
+};
+
+// ─── Day column (droppable) ───────────────────────────────────────────────────
+interface DayColumnProps {
+  dateStr: string;
+  shortLabel: string;
+  isToday: boolean;
+  tasks: Task[];
+  onRemove: (id: string) => void;
+}
+
+const DayColumn = ({ dateStr, shortLabel, isToday, tasks, onRemove }: DayColumnProps) => {
+  const { setNodeRef, isOver } = useDroppable({ id: `week-day-${dateStr}` });
+  return (
+    <div
+      ref={setNodeRef}
+      className={`flex flex-col rounded-2xl border-2 min-h-[180px] transition-colors ${
+        isOver
+          ? "border-primary/60 bg-primary/5"
+          : isToday
+          ? "border-primary/30 bg-primary/5"
+          : "border-border bg-card"
+      }`}
+    >
+      <div className={`px-3 py-2 border-b text-center flex-shrink-0 ${isToday ? "border-primary/30" : "border-border/60"}`}>
+        <p className={`text-xs font-bold ${isToday ? "text-primary" : "text-foreground"}`}>{shortLabel}</p>
+        {isToday && <span className="text-[10px] text-primary">Today</span>}
+      </div>
+      <div className="flex-1 p-2 space-y-1 overflow-y-auto max-h-60">
+        {tasks.length === 0 ? (
+          <div className={`flex items-center justify-center h-full min-h-[80px] transition-colors ${isOver ? "text-primary" : "text-muted-foreground/30"}`}>
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 4v16m8-8H4" />
+            </svg>
+          </div>
+        ) : (
+          tasks.map((t) => (
+            <DraggableMiniCard key={t.id} task={t} onRemove={() => onRemove(t.id)} />
+          ))
+        )}
+      </div>
+      {tasks.length > 0 && (
+        <div className="px-3 py-1.5 border-t border-border/40 text-[10px] text-muted-foreground text-center">
+          {tasks.length} task{tasks.length !== 1 ? "s" : ""}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ─── Bottom pool card (draggable, shows priority) ─────────────────────────────
+interface PoolBoxProps {
+  title: string;
+  tasks: Task[];
+  accentClass: string;
+  dotClass: string;
+}
+const PoolBox = ({ title, tasks, accentClass, dotClass }: PoolBoxProps) => (
+  <div className="rounded-2xl border border-border bg-card flex flex-col min-h-[160px]">
+    <div className="px-4 py-2.5 border-b border-border/60 flex items-center gap-2">
+      <span className={`w-2 h-2 rounded-full flex-shrink-0 ${dotClass}`} />
+      <h3 className={`text-xs font-bold ${accentClass}`}>{title}</h3>
+      <span className="ml-auto text-xs text-muted-foreground">{tasks.length}</span>
+    </div>
+    <div className="flex-1 p-3 space-y-1.5 overflow-y-auto max-h-52">
+      {tasks.length === 0 ? (
+        <p className="text-xs text-muted-foreground/50 py-3 text-center">No tasks</p>
+      ) : (
+        tasks.map((t) => <DraggableMiniCard key={t.id} task={t} />)
+      )}
+    </div>
+  </div>
+);
+
+// ─── WeekPlanningView ─────────────────────────────────────────────────────────
+export const WeekPlanningView = () => {
+  const { tasks: allTasks, updateTaskRich } = useTasksStore();
+  const { activeWorkspaceId } = useUIStore();
+  const { workspaces } = useWorkspaceStore();
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
+  );
+
+  const weekDays = useMemo(() => getWeekDays(), []);
+  const weekDateStrs = useMemo(() => weekDays.map((d) => d.dateStr), [weekDays]);
+  // First and last date of the current week (for range checks)
+  const weekStart = weekDays[0]?.dateStr ?? "";
+  const weekEnd   = weekDays[6]?.dateStr ?? "";
+
+  const activeWorkspaceName = workspaces.find((w) => w.id === activeWorkspaceId)?.name ?? null;
+  const tasks = useMemo(
+    () => allTasks.filter((t) => !t.workspace || t.workspace === activeWorkspaceName || !activeWorkspaceName),
+    [allTasks, activeWorkspaceName],
+  );
+
+  const activeTasks = useMemo(
+    () => tasks.filter((t) => (t.status === "active" || t.status === "inProgress") && !t.isTemplate),
+    [tasks]
+  );
+
+  // ── Source of truth: dueDate within this week ─────────────────────────────
+  // A task belongs to a day column if and only if its dueDate matches that day.
+  const dayTasksMap = useMemo(() => {
+    const map: Record<string, Task[]> = {};
+    weekDateStrs.forEach((dateStr) => { map[dateStr] = []; });
+    for (const t of activeTasks) {
+      if (t.dueDate && t.dueDate >= weekStart && t.dueDate <= weekEnd) {
+        map[t.dueDate]?.push(t);
+      }
+    }
+    return map;
+  }, [activeTasks, weekDateStrs, weekStart, weekEnd]);
+
+  // Planned IDs = any task that appears in a day column
+  const plannedThisWeekIds = useMemo(() => {
+    const ids = new Set<string>();
+    weekDateStrs.forEach((dateStr) => {
+      dayTasksMap[dateStr]?.forEach((t) => ids.add(t.id));
+    });
+    return ids;
+  }, [dayTasksMap, weekDateStrs]);
+
+  const unplanned = useMemo(
+    () => activeTasks.filter((t) => !plannedThisWeekIds.has(t.id)),
+    [activeTasks, plannedThisWeekIds]
+  );
+
+  const buckets = useMemo(() => ({
+    high:   unplanned.filter((t) => t.priority === "high"),
+    medium: unplanned.filter((t) => t.priority === "medium"),
+    low:    unplanned.filter((t) => t.priority === "low"),
+    none:   unplanned.filter((t) => !t.priority),
+  }), [unplanned]);
+
+  const activeTask = useMemo(
+    () => activeTasks.find((t) => t.id === activeId) ?? null,
+    [activeTasks, activeId]
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    setActiveId(null);
+    if (!over) return;
+    const overId = String(over.id);
+    if (overId.startsWith("week-day-")) {
+      const toDateStr = overId.replace("week-day-", "");
+      const task = activeTasks.find((t) => t.id === active.id);
+      if (!task) return;
+      if (task.dueDate === toDateStr) return; // dropped on same day — no-op
+      // dueDate is the single source of truth: one write updates all views.
+      updateTaskRich(active.id as string, { dueDate: toDateStr }, task.userId);
+    }
+  };
+
+  const handleRemoveFromDay = (taskId: string, _dateStr: string) => {
+    const task = activeTasks.find((t) => t.id === taskId);
+    // Setting dueDate to undefined removes it from all views (single source of truth).
+    updateTaskRich(taskId, { dueDate: undefined }, task?.userId);
+  };
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={(e) => setActiveId(e.active.id as string)}
+      onDragEnd={handleDragEnd}
+      onDragCancel={() => setActiveId(null)}
+    >
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold text-foreground">Let's plan the week!</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            {(() => {
+              const weekStr = getISOWeekString(new Date());
+              const weekNum = weekStr.split("-W")[1];
+              const days = weekDays;
+              const mon = days[0]?.dateStr ? new Date(days[0].dateStr + "T12:00:00") : new Date();
+              const sun = days[6]?.dateStr ? new Date(days[6].dateStr + "T12:00:00") : new Date();
+              const range = `${mon.toLocaleDateString("en-GB", { day: "numeric", month: "short" })} – ${sun.toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })}`;
+              return `Week ${weekNum} · ${range}`;
+            })()}
+          </p>
+        </div>
+
+        {/* 7-column day grid — carousel on mobile (2 columns visible at a time), grid on desktop */}
+        <div className="sm:grid sm:grid-cols-4 lg:grid-cols-7 sm:gap-3 flex gap-3 overflow-x-auto pb-2 -mx-1 px-1 scrollbar-thin snap-x snap-mandatory">
+          {weekDays.map(({ dateStr, shortLabel, isToday }) => (
+            <div key={dateStr} className="flex-shrink-0 w-[48%] sm:w-auto snap-start">
+              <DayColumn
+                dateStr={dateStr}
+                shortLabel={shortLabel}
+                isToday={isToday}
+                tasks={dayTasksMap[dateStr] ?? []}
+                onRemove={(id) => handleRemoveFromDay(id, dateStr)}
+              />
+            </div>
+          ))}
+        </div>
+
+        {/* Unplanned pool — hide empty boxes */}
+        <div>
+          <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3">
+            Unplanned tasks — drag to a day
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {buckets.high.length > 0 && <PoolBox title="Must have"    tasks={buckets.high}   accentClass="text-red-600 dark:text-red-400"    dotClass="bg-red-500" />}
+            {buckets.medium.length > 0 && <PoolBox title="Should have"  tasks={buckets.medium} accentClass="text-amber-600 dark:text-amber-400" dotClass="bg-amber-500" />}
+            {buckets.low.length > 0 && <PoolBox title="Nice to have" tasks={buckets.low}    accentClass="text-green-600 dark:text-green-400" dotClass="bg-green-500" />}
+            {buckets.none.length > 0 && <PoolBox title="No Priority"  tasks={buckets.none}   accentClass="text-muted-foreground"              dotClass="bg-muted-foreground/40" />}
+            {buckets.high.length === 0 && buckets.medium.length === 0 && buckets.low.length === 0 && buckets.none.length === 0 && (
+              <div className="sm:col-span-2 lg:col-span-4 text-center py-6 text-sm text-muted-foreground/60">
+                All tasks are assigned to days
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <DragOverlay>
+        {activeTask && <MiniCard task={activeTask} />}
+      </DragOverlay>
+    </DndContext>
+  );
+};

--- a/src/app/components/modals/FocusModal.tsx
+++ b/src/app/components/modals/FocusModal.tsx
@@ -1,0 +1,407 @@
+import { useState, useEffect, useRef, useMemo } from "react";
+import { useTasksStore, type Task, type TaskStatus } from "@/store/tasksStore";
+import { useUIStore } from "@/store/uiStore";
+import { useAuthStore } from "@/store/authStore";
+import { usePomodoroStore } from "@/store/pomodoroStore";
+import { useWorkspaceStore } from "@/store/workspaceStore";
+import { useBodyScrollLock } from "@/hooks/useBodyScrollLock";
+import { useBrowserNotifications } from "@/hooks/useBrowserNotifications";
+
+const WORK_DURATION = 25 * 60;
+const BREAK_DURATION = 5 * 60;
+
+const PRIORITY_MAP: Record<string, string> = {
+  low: "bg-green-100 text-green-800 dark:bg-green-900/60 dark:text-green-300",
+  medium: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/60 dark:text-yellow-300",
+  high: "bg-red-100 text-red-800 dark:bg-red-900/60 dark:text-red-300",
+};
+
+export const FocusModal = () => {
+  const { tasks: allTasks, markAsCompleted, updateTaskRich } = useTasksStore();
+  const { modals, closeAllModals, showNotification, setView, activeWorkspaceId } = useUIStore();
+  const { user } = useAuthStore();
+  const { workspaces } = useWorkspaceStore();
+  const { startSession, endSession } = usePomodoroStore();
+  const { notify, playSound } = useBrowserNotifications();
+  const isOpen = modals.focus;
+  useBodyScrollLock(isOpen);
+
+  // Derive workspace-scoped today tasks (no getActiveTasks() — that ignores workspace)
+  const todayTasksSource = useMemo(() => {
+    const _n = new Date();
+    const today = `${_n.getFullYear()}-${String(_n.getMonth() + 1).padStart(2, "0")}-${String(_n.getDate()).padStart(2, "0")}`;
+    const activeWorkspaceName = workspaces.find((w) => w.id === activeWorkspaceId)?.name ?? null;
+    return allTasks.filter(
+      (t) =>
+        (t.status === "active" || t.status === "inProgress") &&
+        !t.isTemplate &&
+        (!activeWorkspaceName || !t.workspace || t.workspace === activeWorkspaceName) &&
+        t.dueDate === today,
+    );
+  }, [allTasks, activeWorkspaceId, workspaces]);
+
+  const [todayTasks, setTodayTasks] = useState<Task[]>([]);
+  const [task, setTask] = useState<Task | null>(null);
+  const [timeLeft, setTimeLeft] = useState(WORK_DURATION);
+  const [isRunning, setIsRunning] = useState(false);
+  const [isBreak, setIsBreak] = useState(false);
+  const [roundsCompleted, setRoundsCompleted] = useState(0);
+
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const isBreakRef = useRef(false);
+  const sessionIdRef = useRef<string | null>(null);
+  const notifyRef = useRef(notify);
+  const playSoundRef = useRef(playSound);
+  useEffect(() => { notifyRef.current = notify; }, [notify]);
+  useEffect(() => { playSoundRef.current = playSound; }, [playSound]);
+
+  const resetTimer = (toBreak?: boolean) => {
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    setIsRunning(false);
+    const brk = toBreak ?? isBreakRef.current;
+    isBreakRef.current = brk;
+    setIsBreak(brk);
+    setTimeLeft(brk ? BREAK_DURATION : WORK_DURATION);
+  };
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setTodayTasks(todayTasksSource);
+    setTask(todayTasksSource[0] ?? null);
+    resetTimer(false);
+    sessionIdRef.current = null;
+    setRoundsCompleted(0);
+  }, [isOpen, todayTasksSource]);
+
+  useEffect(() => {
+    if (!isRunning) return;
+    intervalRef.current = setInterval(() => {
+      setTimeLeft((t) => {
+        if (t <= 1) {
+          if (intervalRef.current) clearInterval(intervalRef.current);
+          setIsRunning(false);
+          if (sessionIdRef.current) {
+            endSession(sessionIdRef.current, user?.id);
+            sessionIdRef.current = null;
+          }
+          const nowBreak = isBreakRef.current;
+          showNotification(
+            nowBreak
+              ? "☕ Break over! Ready for the next session?"
+              : "✅ Work session complete! Take a break.",
+            nowBreak ? "info" : "success",
+          );
+          // Browser notification + sound alert
+          if (nowBreak) {
+            notifyRef.current("☕ Break over!", "Ready for the next work session?");
+            playSoundRef.current("break_done");
+          } else {
+            notifyRef.current("✅ Work session complete!", "Time for a well-deserved break.");
+            playSoundRef.current("work_done");
+          }
+          if (!nowBreak) {
+            setRoundsCompleted((r) => r + 1);
+          }
+          const next = !nowBreak;
+          isBreakRef.current = next;
+          setIsBreak(next);
+          setTimeLeft(next ? BREAK_DURATION : WORK_DURATION);
+          return 0;
+        }
+        return t - 1;
+      });
+    }, 1000);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isRunning]);
+
+  const close = () => {
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    setIsRunning(false);
+    // Restore inProgress tasks to active when closing without completing
+    todayTasks.forEach((t) => {
+      if (t.status === 'inProgress') {
+        void updateTaskRich(t.id, { status: 'active' as TaskStatus }, t.userId);
+      }
+    });
+    closeAllModals();
+  };
+
+  const handleStart = () => {
+    const id = startSession(user?.id, task?.id, isBreak);
+    sessionIdRef.current = id;
+    setIsRunning(true);
+    // Mark the focused task as inProgress
+    if (task && task.status !== 'inProgress') {
+      void updateTaskRich(task.id, { status: 'inProgress' as TaskStatus }, user?.id);
+    }
+  };
+
+  const handlePause = () => setIsRunning(false);
+
+  const toggleBreak = () => resetTimer(!isBreak);
+
+  const handleMarkComplete = async () => {
+    if (!task) return;
+    await markAsCompleted(task.id, user?.id);
+    showNotification("Task completed!", "success");
+    const remaining = todayTasks.filter((t) => t.id !== task.id);
+    setTask(remaining[0] ?? null);
+    setTodayTasks(remaining);
+    if (remaining.length === 0) close();
+  };
+
+  const handleToggleSubtask = async (subtaskId: string) => {
+    if (!task?.subtasks) return;
+    const updated = task.subtasks.map((st) =>
+      st.id === subtaskId ? { ...st, completed: !st.completed } : st
+    );
+    const updatedTask: Task = { ...task, subtasks: updated };
+    // Optimistic local update
+    setTask(updatedTask);
+    setTodayTasks((prev) => prev.map((t) => t.id === task.id ? updatedTask : t));
+    await updateTaskRich(task.id, { subtasks: updated }, user?.id);
+  };
+
+  const handleGoToPlanDay = () => {
+    close();
+    setView("planDay");
+  };
+
+  const minutes = String(Math.floor(timeLeft / 60)).padStart(2, "0");
+  const seconds = String(timeLeft % 60).padStart(2, "0");
+  const progress = isBreak
+    ? ((BREAK_DURATION - timeLeft) / BREAK_DURATION) * 100
+    : ((WORK_DURATION - timeLeft) / WORK_DURATION) * 100;
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-background flex flex-col overflow-y-auto"
+      role="dialog"
+      aria-modal="true"
+      aria-label="My Flow focus mode"
+    >
+      <button
+        onClick={close}
+        aria-label="Close focus mode"
+        className="absolute top-5 right-5 p-2 hover:bg-accent rounded-lg transition-colors text-foreground z-10 hover:cursor-pointer"
+      >
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+
+      <div className="flex-1 flex flex-col items-center justify-start py-12 px-4 gap-6 max-w-2xl mx-auto w-full">
+
+        {/* Header */}
+        <div className="w-full text-center">
+          <h1 className="text-3xl font-bold text-foreground">My Flow</h1>
+          <p className="text-muted-foreground text-sm mt-1">Stay focused. One task at a time.</p>
+        </div>
+
+        {/* Task Selector */}
+        {todayTasks.length > 0 ? (
+          <div className="w-full bg-card border border-border rounded-2xl p-6 space-y-4">
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+              Currently focusing on
+            </p>
+            <div className="flex flex-col gap-2">
+              {todayTasks.map((t) => (
+                <button
+                  key={t.id}
+                  type="button"
+                  onClick={() => setTask(t)}
+                  className={`flex items-start gap-3 p-3 rounded-xl border-2 text-left transition-all ${
+                    task?.id === t.id
+                      ? "border-primary bg-primary/5"
+                      : "border-border hover:border-primary/40 hover:bg-accent"
+                  }`}
+                >
+                  <div
+                    className={`mt-0.5 w-4 h-4 rounded-full border-2 flex-shrink-0 flex items-center justify-center transition-colors ${
+                      task?.id === t.id ? "border-primary bg-primary" : "border-muted-foreground/40"
+                    }`}
+                  >
+                    {task?.id === t.id && (
+                      <svg className="w-2.5 h-2.5 text-primary-foreground" fill="currentColor" viewBox="0 0 8 8">
+                        <circle cx="4" cy="4" r="3" />
+                      </svg>
+                    )}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium leading-snug">{t.title ?? t.text}</p>
+                    {t.description && (
+                      <p className="text-xs text-muted-foreground mt-0.5 truncate">{t.description}</p>
+                    )}
+                    <div className="flex flex-wrap gap-1.5 mt-1">
+                      {t.priority && (
+                        <span className={`text-[11px] px-1.5 py-0.5 rounded-full font-medium ${PRIORITY_MAP[t.priority] ?? ""}`}>
+                          {t.priority}
+                        </span>
+                      )}
+                      {t.category && (
+                        <span className="text-[11px] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground">
+                          {t.category}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+            {task && (
+              <button
+                onClick={handleMarkComplete}
+                className="px-4 py-2 bg-green-600 hover:bg-green-700 rounded-lg text-sm font-medium transition-colors text-white hover:cursor-pointer" aria-label="Close focus"
+              >
+                ✓ Mark as Completed
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="w-full bg-card border border-border rounded-2xl p-8 text-center space-y-4">
+            <div className="w-16 h-16 rounded-full bg-muted mx-auto flex items-center justify-center">
+              <svg className="w-8 h-8 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+              </svg>
+            </div>
+            <div>
+              <p className="text-foreground font-medium">No tasks planned for today</p>
+              <p className="text-muted-foreground text-sm mt-1">
+                Plan your day first — then come back to focus.
+              </p>
+            </div>
+            <button
+              onClick={handleGoToPlanDay}
+              className="inline-flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm font-medium hover:opacity-90 transition-opacity hover:cursor-pointer"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+              </svg>
+              Plan your day
+            </button>
+          </div>
+        )}
+
+        {/* Pomodoro Timer */}
+        <div className="w-full bg-card border border-border rounded-2xl p-6 text-center space-y-5">
+          <div className="flex items-center justify-center gap-3">
+            <h3 className="text-lg font-semibold text-foreground">Pomodoro Timer</h3>
+            <span
+              className={`text-xs px-2 py-1 rounded-full font-medium ${
+                isBreak ? "bg-teal-700 text-teal-200" : "bg-blue-700 text-blue-200"
+              }`}
+            >
+              {isBreak ? "☕ Break" : "🎯 Work"}
+            </span>
+          </div>
+
+          <div className="relative inline-flex items-center justify-center">
+            <svg className="w-32 h-32 -rotate-90" viewBox="0 0 120 120">
+              <circle cx="60" cy="60" r="54" fill="none" stroke="hsl(var(--border))" strokeWidth="8" />
+              <circle
+                cx="60" cy="60" r="54" fill="none"
+                stroke={isBreak ? "#14b8a6" : "#3b82f6"}
+                strokeWidth="8"
+                strokeLinecap="round"
+                strokeDasharray={`${2 * Math.PI * 54}`}
+                strokeDashoffset={`${2 * Math.PI * 54 * (1 - progress / 100)}`}
+                style={{ transition: "stroke-dashoffset 1s linear" }}
+              />
+            </svg>
+            <span className="absolute text-3xl font-bold font-mono">
+              {minutes}:{seconds}
+            </span>
+          </div>
+
+          <div className="flex gap-2 justify-center">
+            {!isRunning ? (
+              <button
+                onClick={handleStart}
+                className="px-5 py-2.5 bg-green-600 hover:bg-green-700 rounded-lg font-semibold transition-colors text-sm text-white hover:cursor-pointer"
+              >
+                ▶ Start
+              </button>
+            ) : (
+              <button
+                onClick={handlePause}
+                className="px-5 py-2.5 bg-yellow-600 hover:bg-yellow-700 rounded-lg font-semibold transition-colors text-sm text-white hover:cursor-pointer"
+              >
+                ⏸ Pause
+              </button>
+            )}
+            <button
+              onClick={() => { resetTimer(isBreak); sessionIdRef.current = null; }}
+              className="px-5 py-2.5 bg-muted hover:bg-muted/80 text-foreground rounded-lg font-semibold transition-colors text-sm hover:cursor-pointer"
+            >
+              ↺ Reset
+            </button>
+            <button
+              onClick={toggleBreak}
+              className="px-5 py-2.5 bg-muted/80 hover:bg-muted text-foreground rounded-lg font-semibold transition-colors text-sm hover:cursor-pointer"
+            >
+              {isBreak ? "→ Work" : "→ Break"}
+            </button>
+          </div>
+          <p className="text-xs text-muted-foreground">25 min work • 5 min break</p>
+          {roundsCompleted > 0 && (
+            <p className="text-xs text-primary font-medium">
+              {roundsCompleted} round{roundsCompleted !== 1 ? "s" : ""} completed this session
+            </p>
+          )}
+        </div>
+
+        {/* Subtasks */}
+        {task?.subtasks && task.subtasks.length > 0 && (
+          <div className="w-full bg-card border border-border rounded-2xl p-6">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-base font-semibold text-foreground">Subtasks</h3>
+              <span className="text-xs text-muted-foreground">
+                {task.subtasks.filter((s) => s.completed).length}/{task.subtasks.length} done
+              </span>
+            </div>
+            <div className="space-y-2">
+              {task.subtasks.map((st) => (
+                <button
+                  key={st.id}
+                  type="button"
+                  onClick={() => handleToggleSubtask(st.id)}
+                  className="w-full flex items-center gap-3 p-2.5 bg-muted/60 hover:bg-muted rounded-lg transition-colors text-left group"
+                >
+                  <div className={`w-4 h-4 rounded border-2 flex-shrink-0 flex items-center justify-center transition-colors ${
+                    st.completed
+                      ? "bg-green-500 border-green-500"
+                      : "border-border group-hover:border-primary/60"
+                  }`}>
+                    {st.completed && (
+                      <svg className="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                      </svg>
+                    )}
+                  </div>
+                  <span className={`text-sm flex-1 ${st.completed ? "line-through text-muted-foreground" : "text-foreground"}`}>
+                    {st.title}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Notes */}
+        {task?.notes && (
+          <div className="w-full bg-card border border-border rounded-2xl p-6">
+            <h3 className="text-base font-semibold mb-2 text-foreground">Notes</h3>
+            <p className="text-muted-foreground text-sm leading-relaxed whitespace-pre-wrap">{task.notes}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/app/components/modals/RenameModal.tsx
+++ b/src/app/components/modals/RenameModal.tsx
@@ -1,0 +1,120 @@
+import { useState } from "react";
+import { CATEGORY_COLORS } from "@/store/types";
+
+interface RenameModalProps {
+  open: boolean;
+  title: string;           // e.g. "Rename Workspace" or "Rename Category"
+  initialName: string;
+  initialColor: string;
+  onSave: (name: string, color: string) => void;
+  onClose: () => void;
+}
+
+// Inner component — rendered only when open=true, so state always matches initial props
+const RenameModalInner = ({
+  title,
+  initialName,
+  initialColor,
+  onSave,
+  onClose,
+}: Omit<RenameModalProps, "open">) => {
+  const [name, setName] = useState(initialName);
+  const [color, setColor] = useState(initialColor);
+
+  const handleSave = () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    onSave(trimmed, color);
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[200] flex items-center justify-center"
+      onClick={onClose}
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" />
+
+      {/* Modal */}
+      <div
+        className="relative z-10 w-[340px] rounded-2xl border border-border bg-background shadow-2xl p-5 flex flex-col gap-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="text-base font-semibold text-foreground">{title}</h3>
+
+        {/* Name input */}
+        <div className="flex flex-col gap-1.5">
+          <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            Name
+          </label>
+          <input
+            autoFocus
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleSave();
+              if (e.key === "Escape") onClose();
+            }}
+            maxLength={30}
+            className="w-full px-3 py-2 text-sm rounded-lg border border-border bg-background focus:outline-none focus:ring-2 focus:ring-primary/40 placeholder:text-muted-foreground/50"
+            placeholder="Enter name…"
+          />
+        </div>
+
+        {/* Color picker */}
+        <div className="flex flex-col gap-2">
+          <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            Color
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {CATEGORY_COLORS.map((c) => (
+              <button
+                key={c}
+                onClick={() => setColor(c)}
+                className={`w-7 h-7 rounded-full flex-shrink-0 transition-all cursor-pointer ${c} ${
+                  color === c
+                    ? "ring-2 ring-offset-2 ring-offset-background ring-primary scale-110"
+                    : "hover:scale-105 opacity-80 hover:opacity-100"
+                }`}
+                aria-label={c}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Preview */}
+        <div className="flex items-center gap-2.5 px-3 py-2 rounded-lg bg-accent/40">
+          <span className={`w-3 h-3 rounded-full flex-shrink-0 ${color}`} />
+          <span className="text-sm font-medium text-foreground truncate">
+            {name || <span className="text-muted-foreground/60 italic">Preview</span>}
+          </span>
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-2 pt-1">
+          <button
+            onClick={onClose}
+            className="flex-1 py-2 text-sm font-medium rounded-xl border border-border hover:bg-accent transition-colors cursor-pointer"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={!name.trim()}
+            className="flex-1 py-2 text-sm font-semibold rounded-xl bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-40 transition-all cursor-pointer"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const RenameModal = ({ open, ...rest }: RenameModalProps) => {
+  if (!open) return null;
+  // Keyed by initialName+initialColor so state resets whenever target changes
+  return <RenameModalInner key={`${rest.initialName}__${rest.initialColor}`} {...rest} />;
+};

--- a/src/app/components/modals/SearchModal.tsx
+++ b/src/app/components/modals/SearchModal.tsx
@@ -1,0 +1,244 @@
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
+import { useTasksStore, type Task } from "@/store/tasksStore";
+import { useUIStore } from "@/store/uiStore";
+import { useBodyScrollLock } from "@/hooks/useBodyScrollLock";
+
+const RECENT_SEARCHES_KEY = "doitly_recent_searches";
+const MAX_RECENT = 8;
+
+function loadRecentSearches(): string[] {
+  try {
+    const raw = localStorage.getItem(RECENT_SEARCHES_KEY);
+    return raw ? (JSON.parse(raw) as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveRecentSearch(term: string) {
+  const trimmed = term.trim();
+  if (!trimmed) return;
+  const existing = loadRecentSearches().filter((s) => s !== trimmed);
+  const updated = [trimmed, ...existing].slice(0, MAX_RECENT);
+  localStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(updated));
+}
+
+const PRIORITY_COLORS: Record<string, string> = {
+  low: "bg-green-100 text-green-800 dark:bg-green-900/60 dark:text-green-300",
+  medium: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/60 dark:text-yellow-300",
+  high: "bg-red-100 text-red-800 dark:bg-red-900/60 dark:text-red-300",
+};
+
+const PRIORITY_LABELS: Record<string, string> = {
+  low: "Nice to have",
+  medium: "Should have",
+  high: "Must have",
+};
+
+function formatDate(dateStr: string): string | null {
+  if (!dateStr) return null;
+  const d = new Date(dateStr);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  d.setHours(0, 0, 0, 0);
+  if (d.getTime() === today.getTime()) return "Today";
+  const tomorrow = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  if (d.getTime() === tomorrow.getTime()) return "Tomorrow";
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+export const SearchModal = () => {
+  const { searchTasks } = useTasksStore();
+  const { modals, closeAllModals, openTaskModal } = useUIStore();
+  const isOpen = modals.search;
+  useBodyScrollLock(isOpen);
+
+  const [query, setQuery] = useState("");
+  const [recentSearches, setRecentSearches] = useState<string[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Reset query when modal opens and auto-focus
+  useEffect(() => {
+    if (!isOpen) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setQuery("");
+    setRecentSearches(loadRecentSearches());
+    setTimeout(() => inputRef.current?.focus(), 50);
+  }, [isOpen]);
+
+  // Derive results from query directly (no separate state needed)
+  const results = useMemo(
+    () => (query.trim() ? searchTasks(query) : []),
+    [query, searchTasks]
+  );
+
+  const handleOpenTask = useCallback((task: Task) => {
+    if (query.trim()) saveRecentSearch(query);
+    closeAllModals();
+    setTimeout(() => openTaskModal(task), 100);
+  }, [query, closeAllModals, openTaskModal]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && query.trim()) {
+      saveRecentSearch(query);
+      setRecentSearches(loadRecentSearches());
+    }
+  };
+
+  const handleRecentClick = (term: string) => {
+    setQuery(term);
+    inputRef.current?.focus();
+  };
+
+  const removeRecent = (term: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    const updated = loadRecentSearches().filter((s) => s !== term);
+    localStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(updated));
+    setRecentSearches(updated);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-start justify-center pt-20 p-4"
+      onClick={(e) => e.target === e.currentTarget && closeAllModals()}
+    >
+      <div
+        className="bg-card border border-border rounded-2xl shadow-2xl w-full max-w-2xl overflow-hidden"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Search tasks"
+      >
+        {/* Search input */}
+        <div className="p-4 border-b border-border flex items-center gap-3">
+          <svg className="w-5 h-5 text-muted-foreground flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+          <input
+            ref={inputRef}
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Search tasks by title, description, tags..."
+            aria-label="Search tasks"
+            className="flex-1 py-1 bg-transparent text-foreground placeholder-muted-foreground focus:outline-none text-base"
+          />
+          <button
+            onClick={closeAllModals}
+            aria-label="Close search"
+            className="px-2 py-1 rounded-lg hover:bg-accent transition-colors text-muted-foreground text-xs font-medium hover:cursor-pointer"
+          >
+            Esc
+          </button>
+        </div>
+
+        {/* Results */}
+        <div className="max-h-96 overflow-y-auto">
+          {query.trim() === "" ? (
+            recentSearches.length > 0 ? (
+              <div className="p-3">
+                <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider px-1 mb-2">Recent searches</p>
+                <div className="space-y-0.5">
+                  {recentSearches.map((term) => (
+                    <button
+                      key={term}
+                      onClick={() => handleRecentClick(term)}
+                      className="w-full flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-accent text-left group transition-colors"
+                    >
+                      <svg className="w-4 h-4 text-muted-foreground/50 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                      </svg>
+                      <span className="flex-1 text-sm text-foreground truncate">{term}</span>
+                      <span
+                        role="button"
+                        tabIndex={0}
+                        onClick={(e) => removeRecent(term, e)}
+                        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") removeRecent(term, e as unknown as React.MouseEvent); }}
+                        className="opacity-0 group-hover:opacity-100 p-1 rounded hover:bg-muted text-muted-foreground transition-all"
+                        aria-label={`Remove "${term}" from recent searches`}
+                      >
+                        <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <div className="p-8 text-center text-muted-foreground">
+                <svg className="w-10 h-10 mx-auto mb-3 opacity-30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                </svg>
+                <p className="text-sm">Type to search tasks</p>
+              </div>
+            )
+          ) : results.length === 0 ? (
+            <div className="p-8 text-center text-muted-foreground">
+              <p className="text-sm">
+                No tasks found for <span className="font-semibold">"{query}"</span>
+              </p>
+            </div>
+          ) : (
+            <div className="divide-y divide-border/50">
+              {results.map((task) => (
+                <button
+                  key={task.id}
+                  onClick={() => handleOpenTask(task)}
+                  className="w-full text-left p-4 hover:bg-accent transition-colors flex items-start gap-3"
+                >
+                  <div
+                    className={`mt-1 w-2 h-2 rounded-full flex-shrink-0 ${
+                      task.status === "completed" ? "bg-muted-foreground/40" : "bg-blue-500"
+                    }`}
+                  />
+                  <div className="flex-1 min-w-0">
+                    <p
+                      className={`text-sm font-semibold ${
+                        task.status === "completed"
+                          ? "line-through text-muted-foreground"
+                          : "text-foreground"
+                      }`}
+                    >
+                      {task.title ?? task.text}
+                    </p>
+                    {task.description && (
+                      <p className="text-xs text-muted-foreground mt-0.5 truncate">{task.description}</p>
+                    )}
+                    <div className="flex flex-wrap gap-1.5 mt-1.5">
+                      {task.priority && (
+                        <span className={`text-[11px] px-1.5 py-0.5 rounded-full font-medium ${PRIORITY_COLORS[task.priority] ?? ""}`}>
+                          {PRIORITY_LABELS[task.priority ?? ""] ?? task.priority}
+                        </span>
+                      )}
+                      {task.dueDate && (
+                        <span className="text-[11px] text-muted-foreground">{formatDate(task.dueDate)}</span>
+                      )}
+                      {task.tags?.map((tag) => (
+                        <span key={tag} className="text-[11px] bg-muted text-muted-foreground px-1.5 py-0.5 rounded-full">
+                          #{tag}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                  <svg className="w-4 h-4 text-muted-foreground/40 flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                  </svg>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {results.length > 0 && (
+          <div className="px-4 py-2 border-t border-border/50 text-xs text-muted-foreground">
+            {results.length} result{results.length !== 1 ? "s" : ""} — click to edit
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/app/components/modals/SettingsModal.tsx
+++ b/src/app/components/modals/SettingsModal.tsx
@@ -1,0 +1,240 @@
+import { useState, useEffect, useRef } from "react";
+import { useTheme } from "next-themes";
+import { useUIStore } from "@/store/uiStore";
+import { useBodyScrollLock } from "@/hooks/useBodyScrollLock";
+import type { AppSettings } from "@/store/types";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+
+interface ToggleProps {
+  label: string;
+  description?: string;
+  checked: boolean;
+  onChange: (val: boolean) => void;
+}
+
+function Toggle({ label, description, checked, onChange }: ToggleProps) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div>
+        <p className="text-sm font-semibold text-foreground">{label}</p>
+        {description && <p className="text-xs text-muted-foreground mt-0.5">{description}</p>}
+      </div>
+      <button
+        type="button"
+        onClick={() => onChange(!checked)}
+        className={`relative w-10 h-5 rounded-full transition-colors flex-shrink-0 hover:cursor-pointer ${
+          checked ? "bg-primary" : "bg-muted"
+        }`}
+        role="switch"
+        aria-checked={checked}
+        aria-label={label}
+      >
+        <span
+          className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
+            checked ? "translate-x-5" : "translate-x-0"
+          }`}
+        />
+      </button>
+    </div>
+  );
+}
+
+export const SettingsModal = () => {
+  const { modals, settings, closeAllModals, updateSettings, showNotification } = useUIStore();
+  const { setTheme } = useTheme();
+  const isOpen = modals.settings;
+  useBodyScrollLock(isOpen);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const [form, setForm] = useState<AppSettings>({ ...settings });
+
+  // Reset form to latest settings each time modal is opened
+  const prevIsOpen = useRef(false);
+  useEffect(() => {
+    if (isOpen && !prevIsOpen.current) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setForm({ ...settings });
+    }
+    prevIsOpen.current = isOpen;
+  }, [isOpen, settings]);
+
+  const handleSave = () => {
+    updateSettings(form);
+    // Ensure theme is applied (may already be set via live preview)
+    const themeMap: Record<string, string> = { dark: "dark", light: "light", auto: "system" };
+    setTheme(themeMap[form.theme] ?? form.theme);
+    showNotification("Settings saved", "success");
+    closeAllModals();
+  };
+
+  const handleExport = () => {
+    const STORAGE_KEY = "doitly_tasks_v2";
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const blob = new Blob([raw ?? "[]"], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "doitly-backup.json";
+    a.click();
+    URL.revokeObjectURL(url);
+    showNotification("Data exported!", "success");
+  };
+
+  const handleImport = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      try {
+        const data = ev.target?.result;
+        if (typeof data === "string") {
+          localStorage.setItem("doitly_tasks_v2", data);
+          showNotification("Data imported! Refresh to see changes.", "info");
+        }
+      } catch {
+        showNotification("Import failed", "error");
+      }
+    };
+    reader.readAsText(file);
+    e.target.value = "";
+  };
+
+  const handleClear = () => {
+    localStorage.removeItem("doitly_tasks_v2");
+    showNotification("Local data cleared", "info");
+    closeAllModals();
+    window.location.reload();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4"
+      onClick={(e) => e.target === e.currentTarget && closeAllModals()}
+    >
+      <div className="bg-card border border-border rounded-2xl shadow-2xl w-full max-w-md">
+        {/* Header */}
+        <div className="px-6 py-4 border-b border-border flex items-center justify-between">
+          <h3 className="text-xl font-bold text-foreground">Settings</h3>
+          <button onClick={closeAllModals} className="p-2 hover:bg-accent rounded-lg transition-colors text-muted-foreground hover:cursor-pointer" aria-label="Close settings">
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="p-6 space-y-5">
+          {/* Theme */}
+          <div>
+            <label className="block text-sm font-semibold text-foreground mb-2">Theme</label>
+            <select
+              value={form.theme}
+              onChange={(e) => {
+                const newTheme = e.target.value as AppSettings["theme"];
+                setForm((f) => ({ ...f, theme: newTheme }));
+                // Apply immediately as live preview
+                const themeMap: Record<string, string> = { dark: "dark", light: "light", auto: "system" };
+                setTheme(themeMap[newTheme] ?? newTheme);
+              }}
+              className="w-full px-3 pr-8 py-2 text-sm border border-input rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring hover:cursor-pointer transition-colors"
+            >
+              <option value="dark">Dark</option>
+              <option value="light">Light</option>
+              <option value="auto">Auto (System)</option>
+            </select>
+          </div>
+
+          {/* Toggles */}
+          <div className="space-y-4">
+            <Toggle
+              label="Browser Notifications"
+              description="Get notified when tasks are due"
+              checked={form.notifications}
+              onChange={(v) => setForm((f) => ({ ...f, notifications: v }))}
+            />
+            <Toggle
+              label="Sound Alerts"
+              description="Play sound when Pomodoro timer ends"
+              checked={form.soundAlerts}
+              onChange={(v) => setForm((f) => ({ ...f, soundAlerts: v }))}
+            />
+          </div>
+
+          {/* Save */}
+          <button
+            onClick={handleSave}
+            className="w-full px-4 py-2.5 bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-lg font-semibold hover:shadow-lg hover:shadow-blue-500/20 transition-all duration-200 hover:cursor-pointer"
+          >
+            Save Settings
+          </button>
+
+          {/* Data management */}
+          <div className="border-t border-border pt-5 space-y-2">
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3">
+              Data Management
+            </p>
+            <button
+              onClick={handleExport}
+              className="w-full flex items-center gap-2 px-4 py-2.5 bg-muted text-muted-foreground rounded-lg font-medium hover:bg-accent transition-colors text-sm hover:cursor-pointer"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+              </svg>
+              Export Backup (JSON)
+            </button>
+            <button
+              onClick={() => fileRef.current?.click()}
+              className="w-full flex items-center gap-2 px-4 py-2.5 bg-muted text-muted-foreground rounded-lg font-medium hover:bg-accent transition-colors text-sm hover:cursor-pointer"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l4-4m0 0l4 4m-4-4v12" />
+              </svg>
+              Import Backup
+            </button>
+            <input ref={fileRef} type="file" accept=".json" className="hidden" onChange={handleImport} />
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <button
+                  className="w-full flex items-center gap-2 px-4 py-2.5 bg-red-700/80 text-red-300 rounded-lg font-medium hover:bg-red-700/60 transition-colors text-sm hover:cursor-pointer"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                  Clear Local Data
+                </button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Clear all local data?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will permanently delete <strong>all local tasks</strong>. This action cannot be undone. Make sure you have exported a backup first.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={handleClear}
+                    className="bg-red-600 hover:bg-red-700 text-white"
+                  >
+                    Yes, clear all data
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/app/components/modals/TaskModal.tsx
+++ b/src/app/components/modals/TaskModal.tsx
@@ -1,7 +1,24 @@
 import { useState, useEffect, useRef } from "react";
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { useTasksStore } from "@/store/tasksStore";
 import { useUIStore } from "@/store/uiStore";
 import { useAuthStore } from "@/store/authStore";
+import { useWorkspaceStore } from "@/store/workspaceStore";
+import { useBodyScrollLock } from "@/hooks/useBodyScrollLock";
 import type { Priority, Repeat, TaskFormState, Subtask } from "@/store/types";
 
 const PRIORITIES: Priority[] = ["low", "medium", "high"];
@@ -19,16 +36,44 @@ const PRIORITY_COLORS: Record<Priority, string> = {
   high: "text-red-600 dark:text-red-400",
 };
 
-// ─── SubtaskItem (no drag-and-drop — dnd-kit available from LS-12.1) ─────────
-interface SubtaskItemProps {
+// ─── SortableSubtaskItem ─────────────────────────────────────────────────────
+interface SortableSubtaskProps {
   subtask: Subtask;
   onToggle: () => void;
   onRemove: () => void;
 }
 
-const SubtaskItem = ({ subtask, onToggle, onRemove }: SubtaskItemProps) => {
+const SortableSubtaskItem = ({ subtask, onToggle, onRemove }: SortableSubtaskProps) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: subtask.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+  };
+
   return (
-    <div className="flex items-center gap-2 p-2 bg-muted/30 rounded-lg group">
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-2 p-2 bg-muted/30 rounded-lg group"
+    >
+      {/* Drag handle */}
+      <button
+        type="button"
+        {...attributes}
+        {...listeners}
+        className="p-0.5 opacity-0 group-hover:opacity-40 hover:!opacity-100 text-muted-foreground cursor-grab active:cursor-grabbing transition-opacity flex-shrink-0"
+        tabIndex={-1}
+        aria-label="Drag to reorder"
+      >
+        <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24">
+          <circle cx="9" cy="6" r="1.5" /><circle cx="15" cy="6" r="1.5" />
+          <circle cx="9" cy="12" r="1.5" /><circle cx="15" cy="12" r="1.5" />
+          <circle cx="9" cy="18" r="1.5" /><circle cx="15" cy="18" r="1.5" />
+        </svg>
+      </button>
       <input
         type="checkbox"
         checked={subtask.completed}
@@ -75,6 +120,18 @@ const TaskModalInner = ({
   const [tagInput, setTagInput] = useState("");
   const [errors, setErrors] = useState<Record<string, string>>({});
   const titleRef = useRef<HTMLInputElement>(null);
+
+  const subtaskSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+
+  const handleSubtaskDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIdx = form.subtasks.findIndex((s) => s.id === active.id);
+    const newIdx = form.subtasks.findIndex((s) => s.id === over.id);
+    setForm((f) => ({ ...f, subtasks: arrayMove(f.subtasks, oldIdx, newIdx) }));
+  };
 
   // Auto-focus title on mount
   useEffect(() => {
@@ -391,16 +448,27 @@ const TaskModalInner = ({
               </button>
             </div>
             {form.subtasks.length > 0 && (
-              <div className="space-y-1">
-                {form.subtasks.map((st, idx) => (
-                  <SubtaskItem
-                    key={st.id}
-                    subtask={st}
-                    onToggle={() => toggleSubtask(idx)}
-                    onRemove={() => removeSubtask(idx)}
-                  />
-                ))}
-              </div>
+              <DndContext
+                sensors={subtaskSensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleSubtaskDragEnd}
+              >
+                <SortableContext
+                  items={form.subtasks.map((s) => s.id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <div className="space-y-1">
+                    {form.subtasks.map((st, idx) => (
+                      <SortableSubtaskItem
+                        key={st.id}
+                        subtask={st}
+                        onToggle={() => toggleSubtask(idx)}
+                        onRemove={() => removeSubtask(idx)}
+                      />
+                    ))}
+                  </div>
+                </SortableContext>
+              </DndContext>
             )}
           </div>
 
@@ -431,23 +499,16 @@ export const TaskModal = () => {
   const { addTaskRich, updateTaskRich, tasks } = useTasksStore();
   const { modals, editingTask, closeAllModals, showNotification, categories, activeWorkspaceId } = useUIStore();
   const { user } = useAuthStore();
+  const { workspaces, activeWorkspaceId: wsStoreActiveId } = useWorkspaceStore();
   const isOpen = modals.task;
 
-  // Lock body scroll while modal is open
-  useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "";
-    }
-    return () => { document.body.style.overflow = ""; };
-  }, [isOpen]);
+  useBodyScrollLock(isOpen);
 
   if (!isOpen) return null;
 
   // Determine the active workspace name for auto-assigning to new tasks
-  const resolvedWsId = activeWorkspaceId;
-  const activeWorkspaceName = resolvedWsId ?? "";
+  const resolvedWsId = activeWorkspaceId ?? wsStoreActiveId;
+  const activeWorkspaceName = workspaces.find((w) => w.id === resolvedWsId)?.name ?? workspaces[0]?.name ?? "";
 
   // Always resolve the editing task from the live tasks array so we get
   // fresh data even if the modal was opened with a stale reference.
@@ -481,7 +542,7 @@ export const TaskModal = () => {
         description: prefillSource.description ?? "",
         dueDate: prefillSource.dueDate ?? "",
         priority: prefillSource.priority ?? "medium",
-        workspace: prefillSource.workspace ?? activeWorkspaceName,
+        workspace: prefillSource.workspace ?? (workspaces[0]?.name ?? ""),
         category: prefillSource.category ?? (categories[0]?.name ?? ""),
         repeat: prefillSource.repeat ?? "none",
         tags: prefillSource.tags ? prefillSource.tags.join(", ") : "",
@@ -535,7 +596,7 @@ export const TaskModal = () => {
       onSubmit={handleSubmit}
       onClose={closeAllModals}
       categories={categories}
-      workspaces={[]}
+      workspaces={workspaces}
     />
   );
 };

--- a/src/app/components/modals/WorkspaceModal.tsx
+++ b/src/app/components/modals/WorkspaceModal.tsx
@@ -1,0 +1,309 @@
+import { useState, useRef, useEffect } from "react";
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useWorkspaceStore } from "@/store/workspaceStore";
+import { useUIStore } from "@/store/uiStore";
+import { useBodyScrollLock } from "@/hooks/useBodyScrollLock";
+import { CATEGORY_COLORS } from "@/store/types";
+import type { Workspace } from "@/store/types";
+
+const MAX_WORKSPACES = 3;
+
+interface EditRowProps {
+  ws: Workspace;
+  isActive: boolean;
+  onRename: (name: string, color: string) => void;
+  onRemove: () => void;
+  canRemove: boolean;
+}
+
+const WorkspaceRow = ({ ws, isActive, onRename, onRemove, canRemove }: EditRowProps) => {
+  const [editing, setEditing] = useState(false);
+  const [editName, setEditName] = useState(ws.name);
+  const [editColor, setEditColor] = useState(ws.color);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: ws.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+  };
+
+  const startEdit = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setEditName(ws.name);
+    setEditColor(ws.color);
+    setEditing(true);
+    setTimeout(() => inputRef.current?.focus(), 30);
+  };
+
+  const commitEdit = () => {
+    const trimmed = editName.trim();
+    if (trimmed) onRename(trimmed, editColor);
+    setEditing(false);
+  };
+
+  const cancelEdit = () => {
+    setEditName(ws.name);
+    setEditColor(ws.color);
+    setEditing(false);
+  };
+
+  useEffect(() => {
+    if (!editing) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Enter") commitEdit();
+      if (e.key === "Escape") cancelEdit();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`group flex items-center gap-2 px-3 py-2.5 rounded-xl border transition-colors ${
+        isActive ? "border-primary/40 bg-primary/5" : "border-border hover:bg-accent"
+      }`}
+    >
+      <button
+        {...attributes}
+        {...listeners}
+        type="button"
+        className="p-0.5 opacity-0 group-hover:opacity-40 hover:!opacity-100 text-muted-foreground cursor-grab active:cursor-grabbing transition-opacity flex-shrink-0"
+        tabIndex={-1}
+        aria-label="Drag to reorder"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+          <circle cx="9" cy="6" r="1.5" /><circle cx="15" cy="6" r="1.5" />
+          <circle cx="9" cy="12" r="1.5" /><circle cx="15" cy="12" r="1.5" />
+          <circle cx="9" cy="18" r="1.5" /><circle cx="15" cy="18" r="1.5" />
+        </svg>
+      </button>
+
+      {editing ? (
+        <div className="flex-1 space-y-2">
+          <input
+            ref={inputRef}
+            type="text"
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+            maxLength={30}
+            className="w-full px-2 py-1 text-sm rounded-lg border border-border bg-background focus:outline-none focus:ring-2 focus:ring-primary/30"
+          />
+          <div className="flex items-center gap-1.5 flex-wrap">
+            {CATEGORY_COLORS.slice(0, 8).map((c) => (
+              <button
+                key={c}
+                type="button"
+                onClick={() => setEditColor(c)}
+                className={`w-5 h-5 rounded-full ${c} transition-transform ${editColor === c ? "ring-2 ring-offset-1 ring-primary scale-110" : "hover:scale-105"}`}
+              />
+            ))}
+          </div>
+          <div className="flex gap-1.5">
+            <button type="button" onClick={commitEdit} disabled={!editName.trim()}
+              className="flex-1 py-1 text-xs font-medium rounded-lg bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-40">
+              Save
+            </button>
+            <button type="button" onClick={cancelEdit}
+              className="flex-1 py-1 text-xs font-medium rounded-lg border border-border hover:bg-accent">
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <button type="button" className="flex-1 flex items-center gap-2.5 text-left min-w-0"
+            onDoubleClick={startEdit} title="Double-click to rename">
+            <span className={`w-3 h-3 rounded-full flex-shrink-0 ${ws.color}`} />
+            <span className="text-sm font-medium truncate">{ws.name}</span>
+            {isActive && (
+              <span className="text-[10px] bg-primary/10 text-primary px-1.5 py-0.5 rounded font-medium flex-shrink-0">
+                Active
+              </span>
+            )}
+          </button>
+          <button type="button" onClick={startEdit}
+            className="opacity-0 group-hover:opacity-60 hover:!opacity-100 p-1 rounded hover:bg-accent text-muted-foreground transition-all"
+            aria-label="Rename workspace">
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+            </svg>
+          </button>
+          {canRemove && (
+            <button type="button" onClick={(e) => { e.stopPropagation(); onRemove(); }}
+              className="opacity-0 group-hover:opacity-60 hover:!opacity-100 p-1 rounded hover:bg-destructive/10 hover:text-destructive text-muted-foreground transition-all"
+              aria-label="Remove workspace">
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export const WorkspaceModal = () => {
+  const { modals, closeAllModals } = useUIStore();
+  const { workspaces, activeWorkspaceId, addWorkspace, removeWorkspace, renameWorkspace, setActiveWorkspace, reorderWorkspaces } = useWorkspaceStore();
+
+  const [newName, setNewName] = useState("");
+  const [newColor, setNewColor] = useState<string>(CATEGORY_COLORS[0]);
+  const [showForm, setShowForm] = useState(false);
+  const [inviteEmail, setInviteEmail] = useState("");
+
+  useBodyScrollLock(modals.workspace);
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIdx = workspaces.findIndex((w) => w.id === active.id);
+    const newIdx = workspaces.findIndex((w) => w.id === over.id);
+    reorderWorkspaces(arrayMove(workspaces, oldIdx, newIdx));
+  };
+
+  if (!modals.workspace) return null;
+
+  const handleCreate = () => {
+    const trimmed = newName.trim();
+    if (!trimmed || workspaces.length >= MAX_WORKSPACES) return;
+    addWorkspace(trimmed, newColor);
+    setNewName("");
+    setNewColor(CATEGORY_COLORS[0]);
+    setShowForm(false);
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm" onClick={closeAllModals} />
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-4 pointer-events-none">
+        <div
+          className="bg-card border border-border rounded-2xl shadow-2xl w-full max-w-md pointer-events-auto"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Workspaces and Teams"
+        >
+
+          <div className="flex items-center justify-between px-6 py-4 border-b border-border">
+            <div className="flex items-center gap-2.5 text-foreground">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                  d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+              <h3 className="text-lg font-bold">Workspaces & Teams</h3>
+            </div>
+            <button onClick={closeAllModals}
+              className="p-1.5 rounded-lg hover:bg-accent transition-colors text-muted-foreground hover:text-foreground hover:cursor-pointer"
+              aria-label="Close workspaces and teams">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          <div className="p-6 space-y-6 max-h-[70vh] overflow-y-auto">
+
+            <section className="space-y-3">
+              <h4 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">Your Workspaces</h4>
+              <p className="text-xs text-muted-foreground -mt-1">Double-click a workspace to rename or change its color. Drag to reorder. Switch the active workspace from the header.</p>
+
+              <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                <SortableContext items={workspaces.map((w) => w.id)} strategy={verticalListSortingStrategy}>
+                  <div className="space-y-2">
+                    {workspaces.map((ws) => (
+                      <WorkspaceRow key={ws.id} ws={ws}
+                        isActive={activeWorkspaceId === ws.id}
+                        onRename={(name, color) => renameWorkspace(ws.id, name, color)}
+                        onRemove={() => removeWorkspace(ws.id)}
+                        canRemove={workspaces.length > 1}
+                      />
+                    ))}
+                  </div>
+                </SortableContext>
+              </DndContext>
+
+              {showForm ? (
+                <div className="space-y-3 pt-1">
+                  <input autoFocus type="text" value={newName} onChange={(e) => setNewName(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === "Enter") handleCreate(); if (e.key === "Escape") setShowForm(false); }}
+                    placeholder="Workspace name…" maxLength={30}
+                    className="w-full px-3 py-2 text-sm rounded-lg border border-border bg-background focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  />
+                  <div className="flex items-center gap-2 flex-wrap">
+                    {CATEGORY_COLORS.slice(0, 8).map((c) => (
+                      <button key={c} type="button" onClick={() => setNewColor(c)}
+                        className={`w-6 h-6 rounded-full ${c} transition-transform ${newColor === c ? "ring-2 ring-offset-2 ring-primary scale-110" : "hover:scale-105"}`}
+                      />
+                    ))}
+                  </div>
+                  <div className="flex gap-2">
+                    <button onClick={handleCreate} disabled={!newName.trim()}
+                      className="flex-1 py-2 text-sm font-medium rounded-lg bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-40 transition-opacity">
+                      Create
+                    </button>
+                    <button onClick={() => { setShowForm(false); setNewName(""); }}
+                      className="flex-1 py-2 text-sm font-medium rounded-lg border border-border hover:bg-accent transition-colors">
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <button onClick={() => setShowForm(true)} disabled={workspaces.length >= MAX_WORKSPACES}
+                  className="w-full py-2.5 text-sm font-medium rounded-xl border border-dashed border-border hover:border-primary/40 hover:bg-primary/5 text-muted-foreground hover:text-primary disabled:opacity-40 disabled:cursor-not-allowed transition-all">
+                  + New Workspace
+                  {workspaces.length >= MAX_WORKSPACES && <span className="ml-2 text-xs">(limit {MAX_WORKSPACES}/{MAX_WORKSPACES})</span>}
+                </button>
+              )}
+            </section>
+
+            <section className="space-y-3 border-t border-border pt-5">
+              <h4 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">Team Members</h4>
+              <p className="text-xs text-muted-foreground">Team collaboration coming soon.</p>
+              <div className="flex gap-2">
+                <input type="email" value={inviteEmail} onChange={(e) => setInviteEmail(e.target.value)}
+                  placeholder="colleague@email.com"
+                  className="flex-1 px-3 py-2 text-sm rounded-lg border border-border bg-background focus:outline-none focus:ring-2 focus:ring-primary/30"
+                />
+                <button disabled className="px-4 py-2 text-sm font-medium rounded-lg bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 opacity-50 cursor-not-allowed">
+                  Invite
+                </button>
+              </div>
+            </section>
+
+            <section className="space-y-3 border-t border-border pt-5">
+              <h4 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">Shared Lists</h4>
+              <p className="text-xs text-muted-foreground">Share a public read-only link to your task list — coming soon.</p>
+              <button disabled className="w-full py-2.5 text-sm font-medium rounded-xl border border-dashed border-border text-muted-foreground opacity-50 cursor-not-allowed">
+                + Share List
+              </button>
+            </section>
+
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/app/components/statistics/StatisticsPage.tsx
+++ b/src/app/components/statistics/StatisticsPage.tsx
@@ -1,0 +1,491 @@
+import { useState, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { useTasksStore } from "@/store/tasksStore";
+import { usePomodoroStore } from "@/store/pomodoroStore";
+import {
+  AreaChart, Area, BarChart, Bar, LineChart, Line,
+  XAxis, YAxis, CartesianGrid, Tooltip, Legend,
+  ResponsiveContainer, PieChart, Pie, Cell, RadialBarChart, RadialBar,
+} from "recharts";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const MONTHS_SHORT = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+const PALETTE = {
+  created:   "#3b82f6",  // blue
+  completed: "#22c55e",  // green
+  deleted:   "#ef4444",  // red
+  archived:  "#a78bfa",  // violet
+  pomStart:  "#f59e0b",  // amber
+  pomEnd:    "#10b981",  // emerald
+};
+
+interface ChartEntry {
+  label: string;        // "day" or "month" unified as "label"
+  created: number;
+  completed: number;
+  deleted: number;
+  archived: number;
+  pomStarted: number;
+  pomCompleted: number;
+}
+
+function getDaysInMonth(year: number, month: number) {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+// ── Chart dataset checkboxes ─────────────────────────────────────────────────
+interface DatasetKey {
+  key: string;
+  label: string;
+  color: string;
+}
+
+const TASK_DATASETS: DatasetKey[] = [
+  { key: "created",   label: "Created",   color: PALETTE.created },
+  { key: "completed", label: "Completed", color: PALETTE.completed },
+  { key: "deleted",   label: "Deleted",   color: PALETTE.deleted },
+  { key: "archived",  label: "Archived",  color: PALETTE.archived },
+];
+
+const POM_DATASETS: DatasetKey[] = [
+  { key: "started",   label: "Started",   color: PALETTE.pomStart },
+  { key: "completed", label: "Completed", color: PALETTE.pomEnd },
+];
+
+function DatasetCheckboxes({
+  datasets,
+  enabled,
+  onChange,
+}: {
+  datasets: DatasetKey[];
+  enabled: Set<string>;
+  onChange: (key: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-3">
+      {datasets.map((d) => (
+        <label key={d.key} className="flex items-center gap-1.5 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={enabled.has(d.key)}
+            onChange={() => onChange(d.key)}
+            className="w-3.5 h-3.5 rounded accent-[var(--primary)]"
+            style={{ accentColor: d.color }}
+          />
+          <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <span className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ background: d.color }} />
+            {d.label}
+          </span>
+        </label>
+      ))}
+    </div>
+  );
+}
+
+// ── Shared card wrapper ───────────────────────────────────────────────────────
+function ChartCard({
+  title,
+  subtitle,
+  children,
+  datasets,
+  enabledDatasets,
+  onToggleDataset,
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+  datasets?: DatasetKey[];
+  enabledDatasets?: Set<string>;
+  onToggleDataset?: (key: string) => void;
+}) {
+  return (
+    <div className="bg-card border border-border rounded-2xl p-5 space-y-4">
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2">
+        <div>
+          <h3 className="text-base font-semibold text-foreground">{title}</h3>
+          {subtitle && <p className="text-xs text-muted-foreground mt-0.5">{subtitle}</p>}
+        </div>
+        {datasets && enabledDatasets && onToggleDataset && (
+          <DatasetCheckboxes datasets={datasets} enabled={enabledDatasets} onChange={onToggleDataset} />
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// ── Tooltip styling ───────────────────────────────────────────────────────────
+const CustomTooltip = ({ active, payload, label }: { active?: boolean; payload?: { name: string; value: number; color: string }[]; label?: string }) => {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="bg-card border border-border rounded-xl px-3 py-2 shadow-lg text-xs space-y-1">
+      <p className="font-semibold text-foreground mb-1">{label}</p>
+      {payload.map((p) => (
+        <div key={p.name} className="flex items-center gap-2">
+          <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: p.color }} />
+          <span className="text-muted-foreground capitalize">{p.name}:</span>
+          <span className="font-bold text-foreground">{p.value}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+export default function StatisticsPage() {
+  const navigate = useNavigate();
+  const { tasks } = useTasksStore();
+  const { sessions: pomSessions } = usePomodoroStore();
+
+  const [viewMode, setViewMode] = useState<"monthly" | "yearly">("monthly");
+  const [selectedYear, setSelectedYear] = useState(() => new Date().getFullYear());
+  const [selectedMonth, setSelectedMonth] = useState(() => new Date().getMonth()); // 0-indexed
+
+  // Checkbox state
+  const [taskDatasets, setTaskDatasets] = useState<Set<string>>(new Set(["created", "completed"]));
+  const [pomDatasets, setPomDatasets] = useState<Set<string>>(new Set(["started", "completed"]));
+
+  const toggleTask = (key: string) => setTaskDatasets((prev) => {
+    const n = new Set(prev);
+    if (n.has(key)) { n.delete(key); } else { n.add(key); }
+    return n;
+  });
+  const togglePom = (key: string) => setPomDatasets((prev) => {
+    const n = new Set(prev);
+    if (n.has(key)) { n.delete(key); } else { n.add(key); }
+    return n;
+  });
+
+  // ── Monthly data: per-day of selected month ──────────────────────────────
+  const monthlyData = useMemo((): ChartEntry[] => {
+    const days = getDaysInMonth(selectedYear, selectedMonth);
+    const prefix = `${selectedYear}-${String(selectedMonth + 1).padStart(2, "0")}`;
+
+    return Array.from({ length: days }, (_, i) => {
+      const day = i + 1;
+      const dateStr = `${prefix}-${String(day).padStart(2, "0")}`;
+      const nonTemplates = tasks.filter((t) => !t.isTemplate);
+
+      return {
+        label: String(day),
+        created:   nonTemplates.filter((t) => t.createdAt?.startsWith(dateStr)).length,
+        completed: nonTemplates.filter((t) => t.status === "completed" && t.completedAt?.startsWith(dateStr)).length,
+        deleted:   nonTemplates.filter((t) => t.status === "deleted"   && t.deletedAt?.startsWith(dateStr)).length,
+        archived:  nonTemplates.filter((t) => t.status === "archived"  && t.archivedAt?.startsWith(dateStr)).length,
+        pomStarted:   pomSessions.filter((s) => !s.isBreak && s.startedAt?.startsWith(dateStr)).length,
+        pomCompleted: pomSessions.filter((s) => !s.isBreak && s.isEnded && s.startedAt?.startsWith(dateStr)).length,
+      };
+    });
+  }, [tasks, pomSessions, selectedYear, selectedMonth]);
+
+  // ── Yearly data: per-month of selected year ──────────────────────────────
+  const yearlyData = useMemo((): ChartEntry[] => {
+    return MONTHS_SHORT.map((monthLabel, mi) => {
+      const prefix = `${selectedYear}-${String(mi + 1).padStart(2, "0")}`;
+      const nonTemplates = tasks.filter((t) => !t.isTemplate);
+
+      return {
+        label: monthLabel,
+        created:   nonTemplates.filter((t) => t.createdAt?.startsWith(prefix)).length,
+        completed: nonTemplates.filter((t) => (t.status === "completed" && t.completedAt?.startsWith(prefix)) || (t.status === "archived" && t.archivedAt?.startsWith(prefix))).length,
+        deleted:   nonTemplates.filter((t) => t.status === "deleted" && t.deletedAt?.startsWith(prefix)).length,
+        archived:  nonTemplates.filter((t) => t.status === "archived" && t.archivedAt?.startsWith(prefix)).length,
+        pomStarted:   pomSessions.filter((s) => !s.isBreak && s.startedAt?.startsWith(prefix)).length,
+        pomCompleted: pomSessions.filter((s) => !s.isBreak && s.isEnded && s.startedAt?.startsWith(prefix)).length,
+      };
+    });
+  }, [tasks, pomSessions, selectedYear]);
+
+  const data: ChartEntry[] = viewMode === "monthly" ? monthlyData : yearlyData;
+
+  // ── KPI summary cards ─────────────────────────────────────────────────────
+  const totalCreated   = data.reduce((s, d) => s + d.created, 0);
+  const totalCompleted = data.reduce((s, d) => s + d.completed, 0);
+  const totalDeleted   = data.reduce((s, d) => s + d.deleted, 0);
+  const totalPomStart  = data.reduce((s, d) => s + d.pomStarted, 0);
+  const totalPomEnd    = data.reduce((s, d) => s + d.pomCompleted, 0);
+  const completionRate = totalCreated > 0 ? Math.round((totalCompleted / totalCreated) * 100) : 0;
+
+  // ── Pie chart — task status breakdown (all time) ──────────────────────────
+  const nonTemplates = tasks.filter((t) => !t.isTemplate);
+  const pieData = [
+    { name: "Active",    value: nonTemplates.filter((t) => t.status === "active" || t.status === "inProgress").length,    fill: PALETTE.created },
+    { name: "Completed", value: nonTemplates.filter((t) => t.status === "completed").length, fill: PALETTE.completed },
+    { name: "Archived",  value: nonTemplates.filter((t) => t.status === "archived").length,  fill: PALETTE.archived },
+    { name: "Deleted",   value: nonTemplates.filter((t) => t.status === "deleted").length,   fill: PALETTE.deleted },
+  ].filter((d) => d.value > 0);
+
+  // ── Priority breakdown ────────────────────────────────────────────────────
+  const priorityData = [
+    { name: "High",   value: nonTemplates.filter((t) => t.priority === "high"   && (t.status === "active" || t.status === "inProgress")).length, fill: "#ef4444" },
+    { name: "Medium", value: nonTemplates.filter((t) => t.priority === "medium" && (t.status === "active" || t.status === "inProgress")).length, fill: "#f59e0b" },
+    { name: "Low",    value: nonTemplates.filter((t) => t.priority === "low"    && (t.status === "active" || t.status === "inProgress")).length, fill: "#22c55e" },
+    { name: "None",   value: nonTemplates.filter((t) => !t.priority             && (t.status === "active" || t.status === "inProgress")).length, fill: "#94a3b8" },
+  ].filter((d) => d.value > 0);
+
+  // ── Available years ───────────────────────────────────────────────────────
+  const years = useMemo(() => {
+    const ys = new Set<number>();
+    ys.add(new Date().getFullYear());
+    tasks.forEach((t) => {
+      if (t.createdAt) ys.add(new Date(t.createdAt).getFullYear());
+    });
+    return Array.from(ys).sort((a, b) => b - a);
+  }, [tasks]);
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      {/* Header bar */}
+      <div className="sticky top-0 z-20 bg-background/80 backdrop-blur border-b border-border px-4 py-3 flex items-center gap-3">
+        <button
+          onClick={() => navigate(-1)}
+          className="p-2 rounded-lg hover:bg-accent transition-colors text-muted-foreground hover:text-foreground hover:cursor-pointer"
+          aria-label="Go back"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+        <div className="flex-1">
+          <h1 className="text-lg font-bold">Full Statistics</h1>
+          <p className="text-xs text-muted-foreground hidden sm:block">All your productivity data in one place</p>
+        </div>
+
+        {/* Period toggle */}
+        <div className="flex items-center gap-1 bg-muted rounded-lg p-1">
+          <button
+            onClick={() => setViewMode("monthly")}
+            className={`px-3 py-1.5 rounded-md text-xs font-semibold transition-colors hover:cursor-pointer ${viewMode === "monthly" ? "bg-card text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"}`}
+          >
+            Monthly
+          </button>
+          <button
+            onClick={() => setViewMode("yearly")}
+            className={`px-3 py-1.5 rounded-md text-xs font-semibold transition-colors hover:cursor-pointer ${viewMode === "yearly" ? "bg-card text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"}`}
+          >
+            Yearly
+          </button>
+        </div>
+
+        {/* Year / Month selectors */}
+        <div className="flex items-center gap-2">
+          <select
+            value={selectedYear}
+            onChange={(e) => setSelectedYear(Number(e.target.value))}
+            className="text-xs bg-muted text-foreground rounded-lg px-2 pr-7 py-1.5 border-0 outline-none cursor-pointer"
+          >
+            {years.map((y) => <option key={y} value={y}>{y}</option>)}
+          </select>
+          {viewMode === "monthly" && (
+            <select
+              value={selectedMonth}
+              onChange={(e) => setSelectedMonth(Number(e.target.value))}
+              className="text-xs bg-muted text-foreground rounded-lg px-2 pr-7 py-1.5 border-0 outline-none cursor-pointer"
+            >
+              {MONTHS_SHORT.map((m, i) => <option key={i} value={i}>{m}</option>)}
+            </select>
+          )}
+        </div>
+      </div>
+
+      <div className="max-w-6xl mx-auto px-4 py-6 space-y-6">
+
+        {/* ── KPI row ─────────────────────────────────────────────────────── */}
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+          {[
+            { label: "Created",        value: totalCreated,    color: PALETTE.created},
+            { label: "Completed",      value: totalCompleted,  color: PALETTE.completed},
+            { label: "Deleted",        value: totalDeleted,    color: PALETTE.deleted},
+            { label: "Completion %",   value: `${completionRate}%`, color: "#a78bfa", },
+            { label: "Pomodoros",      value: `${totalPomEnd}/${totalPomStart}`, color: PALETTE.pomStart},
+          ].map((kpi) => (
+            <div key={kpi.label} className="bg-card border border-border rounded-2xl p-4 flex flex-col gap-1">
+              <p className="text-2xl font-bold" style={{ color: kpi.color }}>{kpi.value}</p>
+              <p className="text-xs text-muted-foreground">{kpi.label}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* ── Task Activity — Area chart ───────────────────────────────────── */}
+        <ChartCard
+          title="Task Activity"
+          subtitle={viewMode === "monthly" ? `Each day of ${MONTHS_SHORT[selectedMonth]} ${selectedYear}` : `Each month of ${selectedYear}`}
+          datasets={TASK_DATASETS}
+          enabledDatasets={taskDatasets}
+          onToggleDataset={toggleTask}
+        >
+          <ResponsiveContainer width="100%" height={260}>
+            <AreaChart data={data} margin={{ top: 5, right: 10, left: -20, bottom: 0 }}>
+              <defs>
+                {TASK_DATASETS.map((d) => (
+                  <linearGradient key={d.key} id={`grad-${d.key}`} x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%"  stopColor={d.color} stopOpacity={0.3} />
+                    <stop offset="95%" stopColor={d.color} stopOpacity={0} />
+                  </linearGradient>
+                ))}
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+              <XAxis dataKey="label" tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} tickLine={false} axisLine={false} />
+              <YAxis tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} tickLine={false} axisLine={false} allowDecimals={false} />
+              <Tooltip content={<CustomTooltip />} />
+              {TASK_DATASETS.filter((d) => taskDatasets.has(d.key)).map((d) => (
+                <Area
+                  key={d.key} type="monotone" dataKey={d.key} name={d.label}
+                  stroke={d.color} fill={`url(#grad-${d.key})`}
+                  strokeWidth={2} dot={false} activeDot={{ r: 4 }}
+                />
+              ))}
+            </AreaChart>
+          </ResponsiveContainer>
+        </ChartCard>
+
+        {/* ── Created vs Completed — Bar chart ─────────────────────────────── */}
+        <ChartCard
+          title="Created vs Completed"
+          subtitle="Side-by-side comparison per period"
+        >
+          <ResponsiveContainer width="100%" height={240}>
+            <BarChart data={data} margin={{ top: 5, right: 10, left: -20, bottom: 0 }} barGap={2}>
+              <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" vertical={false} />
+              <XAxis dataKey="label" tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} tickLine={false} axisLine={false} />
+              <YAxis tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} tickLine={false} axisLine={false} allowDecimals={false} />
+              <Tooltip content={<CustomTooltip />} />
+              <Bar dataKey="created"   name="Created"   fill={PALETTE.created}   radius={[4,4,0,0]} />
+              <Bar dataKey="completed" name="Completed" fill={PALETTE.completed} radius={[4,4,0,0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartCard>
+
+        {/* ── Pomodoro Sessions — Line chart ───────────────────────────────── */}
+        <ChartCard
+          title="Pomodoro Sessions"
+          subtitle="Work sessions started vs fully completed"
+          datasets={POM_DATASETS}
+          enabledDatasets={pomDatasets}
+          onToggleDataset={togglePom}
+        >
+          <ResponsiveContainer width="100%" height={220}>
+            <LineChart data={data} margin={{ top: 5, right: 10, left: -20, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+              <XAxis dataKey="label" tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} tickLine={false} axisLine={false} />
+              <YAxis tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} tickLine={false} axisLine={false} allowDecimals={false} />
+              <Tooltip content={<CustomTooltip />} />
+              {pomDatasets.has("started") && (
+                <Line type="monotone" dataKey="pomStarted" name="Started" stroke={PALETTE.pomStart} strokeWidth={2} dot={false} activeDot={{ r: 4 }} />
+              )}
+              {pomDatasets.has("completed") && (
+                <Line type="monotone" dataKey="pomCompleted" name="Completed" stroke={PALETTE.pomEnd} strokeWidth={2} dot={false} activeDot={{ r: 4 }} />
+              )}
+            </LineChart>
+          </ResponsiveContainer>
+        </ChartCard>
+
+        {/* ── Two-column: Pie + Priority ──────────────────────────────────── */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+
+          {/* Task status breakdown — Pie */}
+          <ChartCard
+            title="Task Status Breakdown"
+            subtitle="All-time distribution"
+          >
+            {pieData.length > 0 ? (
+              <div className="flex flex-col items-center gap-4">
+                <ResponsiveContainer width="100%" height={200}>
+                  <PieChart>
+                    <Pie
+                      data={pieData} cx="50%" cy="50%"
+                      innerRadius={55} outerRadius={85}
+                      paddingAngle={3} dataKey="value"
+                    >
+                      {pieData.map((entry, idx) => (
+                        <Cell key={idx} fill={entry.fill} />
+                      ))}
+                    </Pie>
+                    <Tooltip formatter={(value, name) => [value, name]} />
+                  </PieChart>
+                </ResponsiveContainer>
+                <div className="flex flex-wrap justify-center gap-3">
+                  {pieData.map((d) => (
+                    <div key={d.name} className="flex items-center gap-1.5 text-xs">
+                      <span className="w-2.5 h-2.5 rounded-full" style={{ background: d.fill }} />
+                      <span className="text-muted-foreground">{d.name}: </span>
+                      <span className="font-bold">{d.value}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <p className="text-center text-muted-foreground text-sm py-8">No data yet</p>
+            )}
+          </ChartCard>
+
+          {/* Priority breakdown — Radial */}
+          <ChartCard
+            title="Active Tasks by Priority"
+            subtitle="Current active task distribution"
+          >
+            {priorityData.length > 0 ? (
+              <div className="flex flex-col items-center gap-4">
+                <ResponsiveContainer width="100%" height={200}>
+                  <RadialBarChart
+                    cx="50%" cy="50%"
+                    innerRadius={30} outerRadius={90}
+                    data={priorityData} startAngle={180} endAngle={0}
+                  >
+                    <RadialBar
+                      dataKey="value"
+                      cornerRadius={6}
+                      label={{ position: "insideStart", fill: "#fff", fontSize: 11 }}
+                    />
+                    <Legend
+                      iconSize={10}
+                      layout="horizontal"
+                      verticalAlign="bottom"
+                      formatter={(value) => <span className="text-xs text-muted-foreground">{value}</span>}
+                    />
+                    <Tooltip formatter={(value, name) => [value, name]} />
+                  </RadialBarChart>
+                </ResponsiveContainer>
+              </div>
+            ) : (
+              <p className="text-center text-muted-foreground text-sm py-8">No active tasks</p>
+            )}
+          </ChartCard>
+        </div>
+
+        {/* ── Cumulative completion trend — Area ──────────────────────────── */}
+        {viewMode === "yearly" && (
+          <ChartCard
+            title="Cumulative Progress"
+            subtitle="Running total of completed tasks through the year"
+          >
+            <ResponsiveContainer width="100%" height={220}>
+              <AreaChart
+                data={yearlyData.reduce<{ label: string; total: number }[]>((acc, d, i) => {
+                  const prev = acc[i - 1]?.total ?? 0;
+                  acc.push({ label: d.label, total: prev + d.completed });
+                  return acc;
+                }, [])}
+                margin={{ top: 5, right: 10, left: -20, bottom: 0 }}
+              >
+                <defs>
+                  <linearGradient id="grad-cumulative" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%"  stopColor={PALETTE.completed} stopOpacity={0.35} />
+                    <stop offset="95%" stopColor={PALETTE.completed} stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                <XAxis dataKey="label" tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} tickLine={false} axisLine={false} />
+                <YAxis tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} tickLine={false} axisLine={false} allowDecimals={false} />
+                <Tooltip content={<CustomTooltip />} />
+                <Area type="monotone" dataKey="total" name="Total Completed" stroke={PALETTE.completed} fill="url(#grad-cumulative)" strokeWidth={2.5} dot={false} />
+              </AreaChart>
+            </ResponsiveContainer>
+          </ChartCard>
+        )}
+
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/tasks/TaskItem.tsx
+++ b/src/app/components/tasks/TaskItem.tsx
@@ -1,0 +1,338 @@
+import { useState, useCallback } from "react";
+import { useTasksStore, type Task } from "@/store/tasksStore";
+import { useUIStore } from "@/store/uiStore";
+import { useAuthStore } from "@/store/authStore";
+import type { Subtask } from "@/store/types";
+
+// ── Badge helpers ────────────────────────────────────────────────────────────
+
+const PRIORITY_BADGE: Record<string, string> = {
+  low: "bg-green-900/60 text-green-300 border border-green-700/40",
+  medium: "bg-yellow-900/60 text-yellow-300 border border-yellow-700/40",
+  high: "bg-red-900/60 text-red-300 border border-red-700/40",
+};
+
+const PRIORITY_LABELS: Record<string, string> = {
+  low: "Nice to have",
+  medium: "Should have",
+  high: "Must have",
+};
+
+// Category colors are derived from live uiStore categories (see TaskItem)
+// Map bg-X-500 Tailwind classes to badge-safe dark classes
+const BG_TO_BADGE: Record<string, string> = {
+  "bg-blue-500":   "bg-blue-900/60 text-blue-300 border border-blue-700/40",
+  "bg-purple-500": "bg-purple-900/60 text-purple-300 border border-purple-700/40",
+  "bg-green-500":  "bg-green-900/60 text-green-300 border border-green-700/40",
+  "bg-amber-500":  "bg-amber-900/60 text-amber-300 border border-amber-700/40",
+  "bg-rose-500":   "bg-rose-900/60 text-rose-300 border border-rose-700/40",
+  "bg-cyan-500":   "bg-cyan-900/60 text-cyan-300 border border-cyan-700/40",
+  "bg-orange-500": "bg-orange-900/60 text-orange-300 border border-orange-700/40",
+  "bg-pink-500":   "bg-pink-900/60 text-pink-300 border border-pink-700/40",
+};
+
+function formatDate(dateStr: string): { label: string; overdue: boolean; today: boolean } {
+  const d = new Date(dateStr);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  d.setHours(0, 0, 0, 0);
+
+  const diff = Math.round((d.getTime() - today.getTime()) / 86_400_000);
+
+  if (diff === 0) return { label: "Today", overdue: false, today: true };
+  if (diff === 1) return { label: "Tomorrow", overdue: false, today: false };
+  if (diff < 0) return { label: `${Math.abs(diff)}d overdue`, overdue: true, today: false };
+  return {
+    label: d.toLocaleDateString("en-US", { month: "short", day: "numeric" }),
+    overdue: false,
+    today: false,
+  };
+}
+
+// ── TaskItem ─────────────────────────────────────────────────────────────────
+
+interface TaskItemProps {
+  task: Task;
+}
+
+export const TaskItem = ({ task }: TaskItemProps) => {
+  const { markAsCompleted, deleteTask, undoTask, updateTaskRich } = useTasksStore();
+  const { toggleTaskSelect, selectedTasks, openTaskModal, showNotification, categories } = useUIStore();
+  const { user } = useAuthStore();
+
+  // Resolve category badge class from live category list
+  const getCategoryBadge = (categoryName: string) => {
+    const cat = categories.find((c) => c.name === categoryName);
+    return cat ? (BG_TO_BADGE[cat.color] ?? "bg-muted text-muted-foreground") : "bg-muted text-muted-foreground";
+  };
+
+  const isSelected = selectedTasks.has(task.id);
+  const isCompleted = task.status === "completed";
+  const displayTitle = task.title ?? task.text;
+
+  const totalSubtasks = task.subtasks?.length ?? 0;
+  const completedSubtasks = task.subtasks?.filter((s) => s.completed).length ?? 0;
+  const [subtasksOpen, setSubtasksOpen] = useState(true);
+
+  // ── Completion animation state: idle | completing | done
+  const [completeAnim, setCompleteAnim] = useState<"idle" | "completing" | "done">("idle");
+
+  const handleCheck = useCallback(async () => {
+    if (isCompleted) {
+      await undoTask(task.id, user?.id);
+      showNotification("Task moved back to active", "info");
+      setCompleteAnim("idle");
+    } else {
+      // Step 1: show green fill
+      setCompleteAnim("completing");
+      // Step 2: after short pause start fade-out, then actually mark complete
+      setTimeout(async () => {
+        setCompleteAnim("done");
+        await markAsCompleted(task.id, user?.id);
+        showNotification("Task completed!", "success");
+      }, 500);
+    }
+  }, [isCompleted, task.id, user?.id, markAsCompleted, undoTask, showNotification]);
+
+  const handleDelete = async () => {
+    await deleteTask(task.id, user?.id);
+    showNotification("Task deleted", "warning");
+  };
+
+  // Toggle a subtask's completed state inline (no modal needed)
+  const handleSubtaskToggle = async (subtaskId: string) => {
+    const updated: Subtask[] = (task.subtasks ?? []).map((s) =>
+      s.id === subtaskId ? { ...s, completed: !s.completed } : s,
+    );
+    await updateTaskRich(task.id, { subtasks: updated }, user?.id);
+  };
+
+  return (
+    <div
+      onDoubleClick={() => openTaskModal(task)}
+      style={{
+        // Fade-out when marking complete
+        opacity: completeAnim === "done" ? 0 : 1,
+        transition: completeAnim === "done" ? "opacity 0.4s ease-out" : "opacity 0.15s",
+        pointerEvents: completeAnim !== "idle" ? "none" : undefined,
+      }}
+      className={`group relative flex items-start gap-2 p-3 rounded-xl border transition-colors duration-150 cursor-pointer
+        ${isSelected ? "border-primary/60 bg-primary/5" : "border-border/50 bg-card hover:border-border hover:shadow-sm"}
+        ${isCompleted ? "opacity-60" : ""}`}
+    >
+      {/* Selection checkbox */}
+      <button
+        onClick={(e) => { e.stopPropagation(); toggleTaskSelect(task.id); }}
+        className={`mt-0.5 w-4 h-4 rounded border-2 flex-shrink-0 flex items-center justify-center transition-colors
+          ${isSelected ? "bg-primary border-primary" : "border-muted-foreground/40 hover:border-primary"}`}
+        aria-label="Select task"
+      >
+        {isSelected && (
+          <svg className="w-2.5 h-2.5 text-primary-foreground" fill="currentColor" viewBox="0 0 12 12">
+            <path d="M10 3L5 8.5 2 5.5" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        )}
+      </button>
+
+      {/* Subtask expand arrow — only shown when task has subtasks */}
+      {totalSubtasks > 0 ? (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); setSubtasksOpen((o) => !o); }}
+          className="mt-0.5 w-5 h-5 flex-shrink-0 flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors rounded"
+          aria-label={subtasksOpen ? "Collapse subtasks" : "Expand subtasks"}
+        >
+          <svg
+            className={`w-3.5 h-3.5 transition-transform duration-200 ${subtasksOpen ? "rotate-90" : ""}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+      ) : (
+        /* Spacer to keep alignment consistent when no subtasks */
+        <span className="w-5 flex-shrink-0" />
+      )}
+
+      {/* Main content */}
+      <div className="flex-1 min-w-0">
+        {/* Title */}
+        <p
+          className={`text-sm font-medium leading-snug break-words ${
+            isCompleted ? "line-through text-muted-foreground" : "text-foreground"
+          }`}
+        >
+          {displayTitle}
+        </p>
+
+        {/* Description */}
+        {task.description && (
+          <p className="text-xs text-muted-foreground mt-0.5 truncate">{task.description}</p>
+        )}
+
+        {/* Badges row */}
+        <div className="flex flex-wrap gap-1.5 mt-1.5">
+          {/* Priority */}
+          {task.priority && (
+            <span className={`text-[11px] px-1.5 py-0.5 rounded-full font-medium ${PRIORITY_BADGE[task.priority] ?? ""}`}>
+              {PRIORITY_LABELS[task.priority] ?? task.priority}
+            </span>
+          )}
+
+          {/* Category */}
+          {task.category && (
+            <span className={`text-[11px] px-1.5 py-0.5 rounded-full font-medium ${getCategoryBadge(task.category)}`}>
+              {task.category}
+            </span>
+          )}
+
+          {/* Due date */}
+          {task.dueDate && (() => {
+            const { label, overdue, today: isToday } = formatDate(task.dueDate);
+            return (
+              <span
+                className={`inline-flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded-full font-medium ${
+                  overdue
+                    ? "bg-red-900/60 text-red-300 border border-red-700/40"
+                    : isToday
+                    ? "bg-blue-900/60 text-blue-300 border border-blue-700/40"
+                    : "bg-muted text-muted-foreground"
+                }`}
+              >
+                <svg className="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <rect x="3" y="4" width="18" height="18" rx="2" strokeWidth="2" />
+                  <path strokeLinecap="round" strokeWidth="2" d="M16 2v4M8 2v4M3 10h18" />
+                </svg>
+                {label}
+              </span>
+            );
+          })()}
+
+          {/* Repeat */}
+          {task.repeat && task.repeat !== "none" && (
+            <span className="text-[11px] px-1.5 py-0.5 rounded-full font-medium bg-muted text-muted-foreground">
+              🔄 {task.repeat}
+            </span>
+          )}
+
+          {/* Subtask count badge */}
+          {totalSubtasks > 0 && (
+            <span className="text-[11px] px-1.5 py-0.5 rounded-full font-medium bg-muted text-muted-foreground">
+              {completedSubtasks}/{totalSubtasks} done
+            </span>
+          )}
+
+          {/* Tags */}
+          {task.tags?.map((tag) => (
+            <span key={tag} className="text-[11px] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground">
+              #{tag}
+            </span>
+          ))}
+        </div>
+
+        {/* Subtasks inline list + progress bar */}
+        {totalSubtasks > 0 && (
+          <>
+            {/* Progress bar */}
+            <div className="mt-2 h-1 rounded-full bg-muted overflow-hidden">
+              <div
+                className="h-full rounded-full bg-green-500 transition-all duration-300"
+                style={{ width: `${(completedSubtasks / totalSubtasks) * 100}%` }}
+              />
+            </div>
+
+            {/* Expandable subtask list */}
+            {subtasksOpen && (
+              <ul className="mt-2 space-y-1 border-l-2 border-border/30 ml-1 pl-3">
+                {task.subtasks!.map((st) => (
+                  <li key={st.id} className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={(e) => { e.stopPropagation(); handleSubtaskToggle(st.id); }}
+                      className={`w-4 h-4 rounded-full border-2 flex-shrink-0 flex items-center justify-center transition-colors ${
+                        st.completed
+                          ? "bg-green-600 border-green-600"
+                          : "border-muted-foreground/40 hover:border-green-500"
+                      }`}
+                      aria-label={st.completed ? "Uncheck subtask" : "Check subtask"}
+                    >
+                      {st.completed && (
+                        <svg className="w-2 h-2 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                        </svg>
+                      )}
+                    </button>
+                    <span
+                      className={`text-xs leading-snug select-none ${
+                        st.completed ? "line-through text-muted-foreground" : "text-foreground/80"
+                      }`}
+                    >
+                      {st.title}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Right-side action bar — always visible on hover, complete btn included */}
+      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0 mt-0.5">
+        {/* Edit */}
+        <button
+          onClick={(e) => { e.stopPropagation(); openTaskModal(task); }}
+          className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+          aria-label="Edit task"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+          </svg>
+        </button>
+
+        {/* Delete */}
+        <button
+          onClick={(e) => { e.stopPropagation(); handleDelete(); }}
+          className="p-1.5 rounded-lg hover:bg-red-900/30 text-muted-foreground hover:text-red-400 transition-colors"
+          aria-label="Delete task"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+          </svg>
+        </button>
+
+        {/* Complete / Undo — moved here from left side */}
+        <button
+          onClick={(e) => { e.stopPropagation(); handleCheck(); }}
+          className={`p-1.5 rounded-lg transition-all duration-300 ${
+            isCompleted || completeAnim !== "idle"
+              ? "text-green-500 hover:bg-green-900/20"
+              : "text-muted-foreground hover:text-green-500 hover:bg-green-900/20"
+          }`}
+          aria-label={isCompleted ? "Undo completion" : "Mark complete"}
+        >
+          {isCompleted || completeAnim !== "idle" ? (
+            /* Filled green circle with checkmark */
+            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <circle
+                cx="12" cy="12" r="9"
+                className={`transition-all duration-300 ${
+                  completeAnim !== "idle" ? "fill-green-600 stroke-green-600" : "fill-green-600 stroke-green-600"
+                }`}
+              />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} stroke="white" d="M8 12l3 3 5-6" />
+            </svg>
+          ) : (
+            /* Empty circle */
+            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+              <circle cx="12" cy="12" r="9" />
+            </svg>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+};
+

--- a/src/app/components/tasks/TaskList.tsx
+++ b/src/app/components/tasks/TaskList.tsx
@@ -1,0 +1,642 @@
+import { useMemo, useState, useEffect } from "react";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
+import { useTasksStore } from "@/store/tasksStore";
+import { useUIStore } from "@/store/uiStore";
+import { useAuthStore } from "@/store/authStore";
+import { useWorkspaceStore } from "@/store/workspaceStore";
+import { TaskItem } from "./TaskItem";
+import type { Task } from "@/store/tasksStore";
+import type { Priority, SortField, View } from "@/store/types";
+import { CalendarView } from "@/app/components/CalendarView";
+import { getISOWeekString } from "@/store/tasksStore";
+
+const PRIORITY_ORDER: Record<Priority, number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+};
+
+const SORT_LABELS: Record<SortField, string> = {
+  created: "Date Created",
+  dueDate: "Due Date",
+  priority: "Priority",
+  title: "Title A-Z",
+};
+
+function sortTasks(tasks: Task[], field: SortField, dir: "asc" | "desc"): Task[] {
+  const sorted = [...tasks].sort((a, b) => {
+    let cmp = 0;
+    if (field === "created") {
+      cmp = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    } else if (field === "dueDate") {
+      const aDate = a.dueDate ? new Date(a.dueDate).getTime() : Infinity;
+      const bDate = b.dueDate ? new Date(b.dueDate).getTime() : Infinity;
+      cmp = aDate - bDate;
+    } else if (field === "priority") {
+      const aP = PRIORITY_ORDER[a.priority ?? "medium"] ?? 2;
+      const bP = PRIORITY_ORDER[b.priority ?? "medium"] ?? 2;
+      cmp = aP - bP;
+    } else if (field === "title") {
+      cmp = (a.title ?? a.text).localeCompare(b.title ?? b.text);
+    }
+    return dir === "asc" ? cmp : -cmp;
+  });
+  return sorted;
+}
+
+// ── Today: collapsible priority accordion ──────────────────────────────────
+const PRIORITY_BUCKETS: { key: Priority; label: string; color: string; dot: string }[] = [
+  { key: "high",   label: "Must have",    color: "text-red-600 dark:text-red-400",    dot: "bg-red-500" },
+  { key: "medium", label: "Should have",  color: "text-amber-600 dark:text-amber-400", dot: "bg-amber-500" },
+  { key: "low",    label: "Nice to have", color: "text-green-600 dark:text-green-400",  dot: "bg-green-500" },
+];
+
+function PriorityAccordion({
+  bucket,
+  tasks,
+}: {
+  bucket: (typeof PRIORITY_BUCKETS)[number];
+  tasks: Task[];
+}) {
+  const [open, setOpen] = useState(true);
+  if (tasks.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-2 py-1 px-1 rounded-lg hover:bg-accent/40 transition-colors w-full text-left group"
+      >
+        <span className={`w-2 h-2 rounded-full flex-shrink-0 ${bucket.dot}`} />
+        <span className={`text-xs font-semibold uppercase tracking-wider ${bucket.color}`}>
+          {bucket.label}
+        </span>
+        <span className="text-xs text-muted-foreground ml-1">({tasks.length})</span>
+        <span className="ml-auto text-muted-foreground/60 group-hover:text-muted-foreground transition-colors">
+          <svg
+            className={`w-3.5 h-3.5 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </span>
+      </button>
+      {open && (
+        <div className="flex flex-col gap-2 pl-4">
+          {tasks.map((task) => (
+            <TaskItem key={task.id} task={task} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Upcoming: group by date with formatted headers ──────────────────────────
+function formatUpcomingHeader(dateStr: string): string {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const tomorrow = new Date(today);
+  tomorrow.setDate(today.getDate() + 1);
+
+  const d = new Date(dateStr + "T00:00:00");
+  d.setHours(0, 0, 0, 0);
+
+  const dayName = d.toLocaleDateString("en-GB", { weekday: "long" });
+  const formatted = d.toLocaleDateString("en-GB", { day: "numeric", month: "short" });
+
+  if (d.getTime() === today.getTime()) {
+    return `${formatted} · Today · ${dayName}`;
+  }
+  if (d.getTime() === tomorrow.getTime()) {
+    return `${formatted} · Tomorrow · ${dayName}`;
+  }
+  return `${formatted} · ${dayName}`;
+}
+
+function UpcomingDateGroup({ dateStr, tasks }: { dateStr: string; tasks: Task[] }) {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-2 py-1 px-1 rounded-lg hover:bg-accent/40 transition-colors w-full text-left group"
+      >
+        <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+          {formatUpcomingHeader(dateStr)}
+        </span>
+        <span className="text-xs text-muted-foreground/60 ml-1">({tasks.length})</span>
+        <span className="ml-auto text-muted-foreground/60 group-hover:text-muted-foreground transition-colors">
+          <svg
+            className={`w-3.5 h-3.5 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </span>
+      </button>
+      {open && (
+        <div className="flex flex-col gap-2 pl-4">
+          {tasks.map((task) => (
+            <TaskItem key={task.id} task={task} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatWeekDayHeader(dateStr: string): string {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const d = new Date(dateStr + "T00:00:00");
+  const dayName = d.toLocaleDateString("en-GB", { weekday: "long" });
+  const formatted = d.toLocaleDateString("en-GB", { day: "numeric", month: "short" });
+  if (d.getTime() === today.getTime()) {
+    return `${formatted} · ${dayName} · Today`;
+  }
+  return `${formatted} · ${dayName}`;
+}
+
+function WeekDayGroup({ dateStr, tasks }: { dateStr: string; tasks: Task[] }) {
+  const [open, setOpen] = useState(true);
+  const _n = new Date();
+  const isToday = dateStr === `${_n.getFullYear()}-${String(_n.getMonth() + 1).padStart(2, '0')}-${String(_n.getDate()).padStart(2, '0')}`;
+  if (tasks.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-2 py-1 px-1 rounded-lg hover:bg-accent/40 transition-colors w-full text-left group"
+      >
+        {isToday && (
+          <span className="w-1.5 h-1.5 rounded-full bg-primary flex-shrink-0" />
+        )}
+        <span
+          className={`text-xs font-semibold uppercase tracking-wider ${
+            isToday ? "text-primary" : "text-muted-foreground"
+          }`}
+        >
+          {formatWeekDayHeader(dateStr)}
+        </span>
+        <span className="text-xs text-muted-foreground/60 ml-1">({tasks.length})</span>
+        <span className="ml-auto text-muted-foreground/60 group-hover:text-muted-foreground transition-colors">
+          <svg
+            className={`w-3.5 h-3.5 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </span>
+      </button>
+      {open && (
+        <div className="flex flex-col gap-2 pl-4">
+          {tasks.map((task) => (
+            <TaskItem key={task.id} task={task} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const TaskList = () => {
+  const {
+    tasks: storeTasks,
+    bulkComplete,
+    bulkDelete,
+    bulkSetPriority,
+  } = useTasksStore();
+
+  const {
+    currentView,
+    currentCategory,
+    sortField,
+    sortDir,
+    selectedTasks,
+    selectAll,
+    clearSelection,
+    setSortField,
+    toggleSortDir,
+    showNotification,
+    openTaskModal,
+    activeWorkspaceId,
+    setView,
+  } = useUIStore();
+
+  const { user } = useAuthStore();
+  const { workspaces } = useWorkspaceStore();
+
+  // Active workspace name — used to scope tasks
+  const activeWorkspaceName = useMemo(
+    () => workspaces.find((w) => w.id === activeWorkspaceId)?.name ?? null,
+    [workspaces, activeWorkspaceId],
+  );
+
+  // Base task filter: only tasks belonging to the active workspace (or unassigned legacy tasks)
+  const workspaceTasks = useMemo(
+    () =>
+      storeTasks.filter(
+        (t) =>
+          !t.workspace ||
+          t.workspace === activeWorkspaceName ||
+          !activeWorkspaceName,
+      ),
+    [storeTasks, activeWorkspaceName],
+  );
+
+  // Resolve tasks for current view — depends on `workspaceTasks` directly so it
+  // re-derives immediately whenever the store mutates (no stale getter issue).
+  const rawTasks = useMemo((): Task[] => {
+    const _now = new Date();
+    const today = `${_now.getFullYear()}-${String(_now.getMonth() + 1).padStart(2, '0')}-${String(_now.getDate()).padStart(2, '0')}`;
+    const todayDate = new Date();
+    todayDate.setHours(0, 0, 0, 0);
+
+    switch (currentView) {
+      case "today":
+        return workspaceTasks.filter(
+          (t) =>
+            (t.status === "active" || t.status === "inProgress") &&
+            !t.isTemplate &&
+            t.dueDate === today,
+        );
+      case "completed":
+        return workspaceTasks.filter((t) => t.status === "completed");
+      case "thisWeek": {
+        // Mon-Sun of current ISO week
+        const now = new Date();
+        now.setHours(0, 0, 0, 0);
+        const mon = new Date(now);
+        mon.setDate(now.getDate() - ((now.getDay() + 6) % 7));
+        const sun = new Date(mon);
+        sun.setDate(mon.getDate() + 6);
+        const monStr = `${mon.getFullYear()}-${String(mon.getMonth() + 1).padStart(2, '0')}-${String(mon.getDate()).padStart(2, '0')}`;
+        const sunStr = `${sun.getFullYear()}-${String(sun.getMonth() + 1).padStart(2, '0')}-${String(sun.getDate()).padStart(2, '0')}`;
+        return workspaceTasks
+          .filter((t) => {
+            if ((t.status !== 'active' && t.status !== 'overdue') || t.isTemplate) return false;
+            return !!t.dueDate && t.dueDate >= monStr && t.dueDate <= sunStr;
+          })
+          .sort((a, b) => (a.dueDate ?? '').localeCompare(b.dueDate ?? ''));
+      }
+      case "overdue":
+        return workspaceTasks.filter(
+          (t) => t.status === "overdue" && !t.isTemplate,
+        );
+      case "calendar":
+        return []; // CalendarView renders itself
+      case "category":
+        if (!currentCategory) return workspaceTasks.filter((t) => (t.status === "active" || t.status === "inProgress" || t.status === "overdue") && !t.isTemplate);
+        if (currentCategory.startsWith("#")) {
+          // Tag view: filter by tags array
+          const tagName = currentCategory.slice(1);
+          return workspaceTasks.filter(
+            (t) =>
+              (t.status === "active" || t.status === "inProgress" || t.status === "overdue") &&
+              !t.isTemplate &&
+              (t.tags ?? []).some((tag) => tag.trim() === tagName),
+          );
+        }
+        return workspaceTasks.filter(
+          (t) => (t.status === "active" || t.status === "inProgress" || t.status === "overdue") && !t.isTemplate && t.category === currentCategory,
+        );
+      default:
+        return workspaceTasks.filter((t) => (t.status === "active" || t.status === "inProgress" || t.status === "overdue") && !t.isTemplate);
+    }
+  }, [workspaceTasks, currentView, currentCategory]);
+
+  const tasks = useMemo(() => sortTasks(rawTasks, sortField, sortDir), [rawTasks, sortField, sortDir]);
+
+  // Today: group by priority bucket
+  const todayBuckets = useMemo(() => {
+    if (currentView !== "today") return null;
+    return PRIORITY_BUCKETS.map((b) => ({
+      ...b,
+      tasks: tasks.filter((t) => (t.priority ?? "medium") === b.key),
+    }));
+  }, [tasks, currentView]);
+
+  // Overdue: group by priority bucket
+  const overdueBuckets = useMemo(() => {
+    if (currentView !== "overdue") return null;
+    return PRIORITY_BUCKETS.map((b) => ({
+      ...b,
+      tasks: tasks.filter((t) => (t.priority ?? "medium") === b.key),
+    }));
+  }, [tasks, currentView]);
+
+  // This Week: group by dueDate
+  const thisWeekGroups = useMemo(() => {
+    if (currentView !== "thisWeek") return null;
+    const now = new Date();
+    now.setHours(0, 0, 0, 0);
+    const mon = new Date(now);
+    mon.setDate(now.getDate() - ((now.getDay() + 6) % 7));
+    const dayMap = new Map<string, Task[]>();
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(mon.getTime() + i * 86400000);
+      dayMap.set(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`, []);
+    }
+    for (const t of tasks) {
+      if (t.dueDate && dayMap.has(t.dueDate)) {
+        dayMap.get(t.dueDate)!.push(t);
+      }
+    }
+    return Array.from(dayMap.entries()).map(([date, dayTasks]) => ({ date, tasks: dayTasks }));
+  }, [tasks, currentView]);
+
+  // Overdue count — used for info bars in Today + This Week
+  const overdueCount = useMemo(
+    () => workspaceTasks.filter((t) => t.status === "overdue" && !t.isTemplate).length,
+    [workspaceTasks],
+  );
+
+  const [overdueBannerDismissed, setOverdueBannerDismissed] = useLocalStorage(
+    "doitly_overdue_banner_dismissed",
+    false,
+  );
+
+  // Re-show the banner whenever new overdue tasks appear
+  useEffect(() => {
+    if (overdueCount > 0) setOverdueBannerDismissed(false);
+  }, [overdueCount, setOverdueBannerDismissed]);
+
+  const allIds = tasks.map((t) => t.id);
+  const allSelected = allIds.length > 0 && allIds.every((id) => selectedTasks.has(id));
+  const someSelected = selectedTasks.size > 0;
+
+  const handleSelectAll = () => {
+    if (allSelected) clearSelection();
+    else selectAll(allIds);
+  };
+
+  const handleBulkComplete = async () => {
+    const ids = [...selectedTasks];
+    await bulkComplete(ids, user?.id);
+    clearSelection();
+    showNotification(`${ids.length} task${ids.length > 1 ? "s" : ""} completed`, "success");
+  };
+
+  const handleBulkDelete = async () => {
+    const ids = [...selectedTasks];
+    await bulkDelete(ids, user?.id);
+    clearSelection();
+    showNotification(`${ids.length} task${ids.length > 1 ? "s" : ""} deleted`, "warning");
+  };
+
+  const handleBulkPriority = async (priority: Priority) => {
+    const ids = [...selectedTasks];
+    await bulkSetPriority(ids, priority, user?.id);
+    clearSelection();
+    showNotification(`Priority set to ${priority}`, "info");
+  };
+
+  // View label with date context
+  const viewLabel = useMemo(() => {
+    if (currentView === "category" && currentCategory) {
+      return currentCategory.startsWith("#") ? currentCategory : currentCategory;
+    }
+    if (currentView === "all") return "All Tasks";
+    if (currentView === "today") {
+      const d = new Date();
+      const dayLabel = d.toLocaleDateString("en-GB", { weekday: "short", day: "numeric", month: "short", year: "numeric" });
+      return `Today — ${dayLabel}`;
+    }
+    if (currentView === "thisWeek") {
+      const weekStr = getISOWeekString(new Date());
+      const weekNum = weekStr.split("-W")[1];
+      // Mon–Sun range
+      const now = new Date();
+      now.setHours(0,0,0,0);
+      const mon = new Date(now);
+      mon.setDate(now.getDate() - ((now.getDay() + 6) % 7));
+      const sun = new Date(mon);
+      sun.setDate(mon.getDate() + 6);
+      const rangeLabel = `${mon.toLocaleDateString("en-GB", { day: "numeric", month: "short" })} – ${sun.toLocaleDateString("en-GB", { day: "numeric", month: "short" })}`;
+      return `This Week — W${weekNum} · ${rangeLabel}`;
+    }
+    if (currentView === "overdue") return "Overdue";
+    if (currentView === "calendar") return "Calendar";
+    return currentView.charAt(0).toUpperCase() + currentView.slice(1);
+  }, [currentView, currentCategory]);
+
+  return (
+    <div className="flex flex-col gap-4 flex-1 min-w-0 pb-8">
+      {/* Calendar view: full self-contained component */}
+      {currentView === "calendar" ? (
+        <CalendarView />
+      ) : (
+      <>
+      {/* Top bar: title + sort */}
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <div className="flex items-center gap-3">
+          <h2 className="text-lg font-bold text-foreground">{viewLabel}</h2>
+          {tasks.length > 0 && (
+            <span className="text-sm text-muted-foreground">({tasks.length})</span>
+          )}
+        </div>
+
+        {/* Sort controls */}
+        <div className="flex items-center gap-2">
+          <select
+            value={sortField}
+            onChange={(e) => setSortField(e.target.value as SortField)}
+            className="text-xs px-2 pr-7 py-1.5 rounded-lg border border-border bg-background text-foreground focus:outline-none focus:ring-1 focus:ring-ring hover:cursor-pointer transition-colors"
+          >
+            {(Object.keys(SORT_LABELS) as SortField[]).map((f) => (
+              <option key={f} value={f}>
+                {SORT_LABELS[f]}
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={toggleSortDir}
+            className="p-1.5 rounded-lg border border-border bg-background text-muted-foreground hover:text-foreground hover:bg-accent transition-colors hover:cursor-pointer"
+            title={sortDir === "asc" ? "Ascending" : "Descending"}
+          >
+            {sortDir === "asc" ? (
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4h13M3 8h9M3 12h5m10 0l-4-4m4 4l-4 4" />
+              </svg>
+            ) : (
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4h13M3 8h9M3 12h5m10 4l-4-4m4 4l-4 4" />
+              </svg>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Overdue info bar — shown in Today and This Week */}
+      {(currentView === "today" || currentView === "thisWeek") && overdueCount > 0 && !overdueBannerDismissed && (
+        <div className="flex items-center gap-3 px-4 py-2.5 rounded-xl bg-red-500/10 border border-red-500/20 text-sm">
+          <svg className="w-4 h-4 text-red-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span className="text-red-600 dark:text-red-400 font-medium flex-1">
+            {overdueCount} task{overdueCount !== 1 ? "s" : ""} became overdue and weren't completed.
+          </span>
+          <button
+            onClick={() => setView("overdue" as View)}
+            className="text-xs font-semibold text-red-600 dark:text-red-400 hover:underline flex-shrink-0 hover:cursor-pointer"
+          >
+            View →
+          </button>
+          <button
+            onClick={() => setOverdueBannerDismissed(true)}
+            className="p-0.5 rounded text-red-400 hover:text-red-600 hover:bg-red-500/20 transition-colors flex-shrink-0 hover:cursor-pointer"
+            aria-label="Dismiss overdue notice"
+            title="Dismiss"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      )}
+
+      {/* Overdue view motivational header */}
+      {currentView === "overdue" && tasks.length > 0 && (
+        <div className="flex items-center gap-3 px-4 py-2.5 rounded-xl bg-amber-500/10 border border-amber-500/20 text-sm">
+          <span className="text-amber-700 dark:text-amber-300 font-medium">
+            These tasks slipped through. No worries - tackle them now or reschedule!
+          </span>
+        </div>
+      )}
+
+      {/* Bulk actions bar */}
+      {someSelected && (
+        <div className="flex items-center gap-2 px-3 py-2 rounded-xl border border-primary/30 bg-primary/5 flex-wrap">
+          <span className="text-sm font-medium text-primary">
+            {selectedTasks.size} selected
+          </span>
+          <div className="flex-1" />
+
+          <button
+            onClick={handleBulkComplete}
+            className="text-xs px-3 py-1.5 rounded-lg bg-green-600 text-white hover:bg-green-700 font-medium transition-colors"
+          >
+            Complete
+          </button>
+
+          {/* Priority dropdown */}
+          <div className="relative">
+            <select
+              onChange={(e) => {
+                if (e.target.value) {
+                  handleBulkPriority(e.target.value as Priority);
+                  e.target.value = "";
+                }
+              }}
+              defaultValue=""
+              className="text-xs px-3 pr-8 py-1.5 rounded-lg bg-blue-600 text-white hover:bg-blue-700 font-medium transition-colors cursor-pointer"
+            >
+              <option value="" disabled>
+                Set Priority
+              </option>
+              <option value="low">Low</option>
+              <option value="medium">Medium</option>
+              <option value="high">High</option>
+            </select>
+          </div>
+
+          <button
+            onClick={handleBulkDelete}
+            className="text-xs px-3 py-1.5 rounded-lg bg-red-600 text-white hover:bg-red-700 font-medium transition-colors"
+          >
+            Delete
+          </button>
+
+          <button
+            onClick={clearSelection}
+            className="text-xs px-3 py-1.5 rounded-lg bg-muted text-muted-foreground hover:bg-accent font-medium transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {/* Select all row (only when tasks exist) */}
+      {tasks.length > 0 && (
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleSelectAll}
+            className={`w-4 h-4 rounded border-2 flex items-center justify-center transition-colors flex-shrink-0
+              ${allSelected ? "bg-primary border-primary" : "border-muted-foreground/40 hover:border-primary"}`}
+            aria-label="Select all"
+          >
+            {allSelected && (
+              <svg className="w-2.5 h-2.5 text-primary-foreground" fill="currentColor" viewBox="0 0 12 12">
+                <path d="M10 3L5 8.5 2 5.5" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            )}
+          </button>
+          <span className="text-xs text-muted-foreground">
+            {allSelected ? "Deselect all" : "Select all"}
+          </span>
+        </div>
+      )}
+
+      {/* Task list */}
+      {tasks.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-20 text-center">
+          <svg className="w-12 h-12 text-muted-foreground/30 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+          </svg>
+          <p className="text-muted-foreground font-medium">
+            {currentView === "overdue" ? "No overdue tasks!" : "No tasks here"}
+          </p>
+          {currentView === "all" && (
+            <button
+              onClick={() => openTaskModal()}
+              className="mt-3 text-sm text-primary hover:underline hover:cursor-pointer"
+            >
+              + Add your first task
+            </button>
+          )}
+        </div>
+      ) : currentView === "today" && todayBuckets ? (
+        // ── Today: priority accordions ─────────────────────────────────────
+        <div className="flex flex-col gap-4">
+          {todayBuckets.map((b) => (
+            <PriorityAccordion key={b.key} bucket={b} tasks={b.tasks} />
+          ))}
+          {todayBuckets.every((b) => b.tasks.length === 0) && (
+            <p className="text-muted-foreground text-sm text-center py-4">No tasks for today</p>
+          )}
+        </div>
+      ) : currentView === "overdue" && overdueBuckets ? (
+        // ── Overdue: priority accordions ──────────────────────────────────
+        <div className="flex flex-col gap-4">
+          {overdueBuckets.map((b) => (
+            <PriorityAccordion key={b.key} bucket={b} tasks={b.tasks} />
+          ))}
+        </div>
+      ) : currentView === "thisWeek" && thisWeekGroups ? (
+        // ── This Week: day-grouped ─────────────────────────────────────────
+        <div className="flex flex-col gap-4">
+          {thisWeekGroups.map((g) => (
+            <WeekDayGroup key={g.date} dateStr={g.date} tasks={g.tasks} />
+          ))}
+          {thisWeekGroups.every((g) => g.tasks.length === 0) && (
+            <p className="text-muted-foreground text-sm text-center py-4">No tasks planned for this week</p>
+          )}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {tasks.map((task) => (
+            <TaskItem key={task.id} task={task} />
+          ))}
+        </div>
+      )}
+      </>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
…als, Sidebar, StatisticsPage

Changes:
- Add TaskList component rendering active/completed/overdue task sections filtered by current view and active workspace
- Add TaskItem component with inline status toggle, priority badge, due date chip, subtask progress bar and edit/delete actions
- Add Sidebar component with view navigation (All, Today, This Week, Overdue, Calendar, Planner, Statistics), workspace switcher and Add Task button
- Add BottomNav component for mobile navigation mirroring Sidebar view links
- Add MobileCategorySheet bottom sheet for mobile workspace/category switching
- Add Notifications component rendering fixed-bottom toast stack consuming uiStore.notifications array
- Add PlannerShell with Day/Week tab switcher routing to DayPlanningView and WeekPlanningView
- Add DayPlanningView with dnd-kit drop zones: today-box (sets dueDate=today) and unplanned pool
- Add WeekPlanningView with seven DayColumn drop zones each setting dueDate to that weekday
- Add MonthPlanningView with calendar grid and month-level task assignment
- Add CalendarView with monthly grid, task chips per day (dnd-kit draggable), unplanned pool and chip × clear button
- Add TaskModal (add/edit) with all rich fields: title, description, dueDate, priority, repeat, tags, subtasks, notes and workspace selector
- Add SearchModal with real-time fuzzy search across title and description fields
- Add FocusModal (Pomodoro timer) with work/break sessions, sound alerts via useBrowserNotifications and session persistence
- Add SettingsModal exposing notification, sound and theme toggles persisted via uiStore settings
- Add WorkspaceModal for creating and renaming workspaces
- Add RenameModal generic rename dialog used by workspace and category rename actions
- Add StatisticsPage with recharts bar/pie charts for task completion rate, overdue count and Pomodoro session history