### PR TITLE
[LS-14] - refactor/footer and unify Auth/Account Sheet layouts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import { Header } from "@/app/components/header";
 import { Sidebar } from "@/app/components/Sidebar";
 import { TaskList } from "@/app/components/tasks/TaskList";
 import { PlannerShell } from "@/app/components/PlannerShell";
-import { Footer } from "@/app/components/footer";
 const TaskModal = lazy(() => import("@/app/components/modals/TaskModal").then(m => ({ default: m.TaskModal })));
 const SearchModal = lazy(() => import("@/app/components/modals/SearchModal").then(m => ({ default: m.SearchModal })));
 const FocusModal = lazy(() => import("@/app/components/modals/FocusModal").then(m => ({ default: m.FocusModal })));
@@ -131,11 +130,6 @@ export default function App() {
           ) : (
             <TaskList />
           )}
-
-          {/* Footer: hidden on mobile — moved to AccountSheet */}
-          <div className="hidden md:block">
-            <Footer />
-          </div>
         </main>
       </div>
 

--- a/src/app/components/auth/AccountSheet.tsx
+++ b/src/app/components/auth/AccountSheet.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
+import { Footer } from "@/app/components/footer";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { User, TrendingUp, CheckCircle, ListTodo, Archive, FileText, Calendar, LogOut, Trash2, Download, Timer, BarChart2 } from "lucide-react";
 import {
@@ -447,30 +448,7 @@ export const AccountSheet: React.FC<AccountSheetProps> = ({ open: controlledOpen
         </div>
 
         {/* Footer — links at the bottom of the account sheet */}
-        <div className="mt-8 pt-4 border-t border-border/40 flex flex-col items-center gap-2 text-sm text-muted-foreground">
-          <p className="flex items-center gap-1">
-            DoItly by
-            <a
-              className="font-semibold text-primary hover:underline transition-all hover:opacity-80"
-              target="_blank"
-              rel="noopener noreferrer"
-              href="https://lszpilowski.com"
-            >
-              LSzpilowski
-            </a>
-          </p>
-          <div className="flex items-center gap-3 text-xs">
-            <p>© {new Date().getFullYear()} DoItly. All rights reserved.</p>
-            <span>•</span>
-            <PrivacyPolicyModal>
-              <button className="text-primary hover:underline transition-all">Privacy Policy</button>
-            </PrivacyPolicyModal>
-            <span>•</span>
-            <GDPRModal>
-              <button className="text-primary hover:underline transition-all">GDPR</button>
-            </GDPRModal>
-          </div>
-        </div>
+        <Footer />
       </SheetContent>
     </Sheet>
   );

--- a/src/app/components/auth/AuthSheet.tsx
+++ b/src/app/components/auth/AuthSheet.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useAuthStore } from '@/store/authStore';
 import { AuthComponent } from './AuthComponent';
+import { Footer } from "@/app/components/footer";
 import {
   Sheet,
   SheetContent,
@@ -37,16 +38,18 @@ export function AuthSheet({ open: controlledOpen, onOpenChange }: AuthSheetProps
           </Button>
         </SheetTrigger>
       )}
-      <SheetContent className='bg-background'>
-        <SheetHeader>
+      <SheetContent side="right" className="max-h-screen w-full sm:max-w-lg overflow-y-auto bg-background flex flex-col">
+        <SheetHeader className="text-center">
           <SheetTitle>Welcome to DoItly</SheetTitle>
           <SheetDescription>
             Sign in to sync your tasks across devices
           </SheetDescription>
-        </SheetHeader>
-        <div className="mt-6">
+          <div className="flex-1 flex items-center justify-center py-8">
           <AuthComponent />
-        </div>
+          </div>
+        </SheetHeader>
+        
+        <Footer />
       </SheetContent>
     </Sheet>
   );

--- a/src/app/components/footer.tsx
+++ b/src/app/components/footer.tsx
@@ -1,42 +1,31 @@
-import React from "react";
 import { PrivacyPolicyModal } from "./legal/PrivacyPolicyModal";
 import { GDPRModal } from "./legal/GDPRModal";
 
 export const Footer = () => {
   return (
-    <footer className="pt-6 mt-auto border-t border-border/40">
-      <div className="flex flex-col md:flex-row justify-between items-center gap-4 text-sm text-muted-foreground">
-        <div className="flex flex-col items-center md:items-start gap-1">
+    <footer className="mt-auto border-t border-border/40">
+      <div className="mt-8 pt-4 flex flex-col items-center gap-2 text-sm text-muted-foreground">
           <p className="flex items-center gap-1">
             DoItly by
-            <a 
-              className="font-semibold text-primary hover:underline transition-all hover:opacity-80" 
-              target="_blank" 
+            <a
+              className="font-semibold text-primary hover:underline transition-all hover:opacity-80"
+              target="_blank"
               rel="noopener noreferrer"
               href="https://lszpilowski.com"
             >
               LSzpilowski
             </a>
           </p>
+          <div className="flex items-center gap-3 text-xs">
+            <p>© {new Date().getFullYear()} DoItly. All rights reserved.</p>
+            <PrivacyPolicyModal>
+              <button className="text-primary hover:underline transition-all">Privacy Policy</button>
+            </PrivacyPolicyModal>
+            <GDPRModal>
+              <button className="text-primary hover:underline transition-all">GDPR</button>
+            </GDPRModal>
+          </div>
         </div>
-        <div className="flex items-center gap-3 text-xs">
-          <p className="text-xs">
-            © {new Date().getFullYear()} DoItly. All rights reserved.
-          </p>
-          <span>•</span>
-          <PrivacyPolicyModal>
-            <button className="text-primary hover:underline transition-all">
-              Privacy Policy
-            </button>
-          </PrivacyPolicyModal>
-          <span>•</span>
-          <GDPRModal>
-            <button className="text-primary hover:underline transition-all">
-              GDPR
-            </button>
-          </GDPRModal>
-        </div>
-      </div>
     </footer>
   );
 };


### PR DESCRIPTION
Changes:
-Moved Footer component out of main app views; now only appears in AuthSheet and AccountSheet panels
- Updated AuthSheet to use the same width and responsive layout as AccountSheet (side="right", w-full sm:max-w-lg, max-h-screen, overflow-y-auto)
- Ensured both sheets expand to full width on mobile and have consistent panel sizing on desktop
- Set up flex column layout so Footer always pins to the bottom of the panel
- Fixed AuthComponent vertical centering in AuthSheet for improved UX