### PR TITLE
[LS-15] - feat/implement habits system with UX improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Sidebar } from "@/app/components/Sidebar";
 import { TaskList } from "@/app/components/tasks/TaskList";
 import { PlannerShell } from "@/app/components/PlannerShell";
 const TaskModal = lazy(() => import("@/app/components/modals/TaskModal").then(m => ({ default: m.TaskModal })));
+const HabitModal = lazy(() => import("@/app/components/modals/HabitModal").then(m => ({ default: m.HabitModal })));
 const SearchModal = lazy(() => import("@/app/components/modals/SearchModal").then(m => ({ default: m.SearchModal })));
 const FocusModal = lazy(() => import("@/app/components/modals/FocusModal").then(m => ({ default: m.FocusModal })));
 const SettingsModal = lazy(() => import("@/app/components/modals/SettingsModal").then(m => ({ default: m.SettingsModal })));
@@ -28,6 +29,7 @@ const PATH_TO_VIEW: Record<string, View> = {
   "this-week": "thisWeek",
   "completed": "completed",
   "overdue": "overdue",
+  "habits": "habits",
   "planner": "planDay",
   "planner-week": "planWeek",
 };
@@ -38,6 +40,7 @@ const VIEW_TO_PATH: Record<View, string> = {
   thisWeek: "/this-week",
   completed: "/completed",
   overdue: "/overdue",
+  habits: "/habits",
   planDay: "/planner",
   planWeek: "/planner-week",
   planMonth: "/planner",
@@ -136,6 +139,7 @@ export default function App() {
       {/* Modals */}
       <Suspense fallback={null}>
         <TaskModal />
+        <HabitModal />
         <SearchModal />
         <FocusModal />
         <SettingsModal />

--- a/src/app/components/DayPlanningView.tsx
+++ b/src/app/components/DayPlanningView.tsx
@@ -74,14 +74,23 @@ const TaskCard = ({ task, dragging, onRemove, showRemove }: TaskCardProps) => {
 
   return (
     <div
-      className={`group flex items-start justify-between gap-2 px-3 py-2.5 rounded-xl border bg-card transition-all ${
-        dragging
-          ? "opacity-50 shadow-lg border-primary/40"
-          : "border-border hover:border-border/80 hover:shadow-sm"
+      className={`group flex items-start justify-between gap-2 px-3 py-2.5 rounded-xl border transition-all ${
+        task.isHabit
+          ? dragging
+            ? "opacity-50 shadow-lg border-emerald-500/40 bg-emerald-500/5"
+            : "border-emerald-500/30 bg-emerald-500/5 hover:border-emerald-500/50 hover:shadow-sm"
+          : dragging
+          ? "opacity-50 shadow-lg border-primary/40 bg-card"
+          : "border-border bg-card hover:border-border/80 hover:shadow-sm"
       }`}
     >
       <div className="flex-1 min-w-0">
         <p className="text-sm font-medium text-foreground truncate">{label}</p>
+        {task.isHabit && (
+          <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400 mb-0.5">
+            🔁 Habit
+          </span>
+        )}
         <div className="flex flex-wrap items-center gap-1.5 mt-1">
           {task.category && (
             <span className="text-[11px] px-1.5 py-0.5 rounded-full bg-accent text-muted-foreground font-medium">

--- a/src/app/components/MonthPlanningView.tsx
+++ b/src/app/components/MonthPlanningView.tsx
@@ -64,7 +64,7 @@ const DraggableChip = ({
       ref={setNodeRef}
       {...attributes}
       {...listeners}
-      className={`group flex items-center gap-1 px-1.5 py-0.5 rounded bg-primary/10 text-primary text-[10px] font-medium overflow-hidden cursor-grab active:cursor-grabbing touch-none select-none border border-primary/20 transition-opacity ${
+      className={`group flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium overflow-hidden cursor-grab active:cursor-grabbing touch-none select-none border transition-opacity ${task.isHabit ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 border-emerald-500/20" : "bg-primary/10 text-primary border-primary/20"} ${
         isDragging ? "opacity-30" : ""
       }`}
     >

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -203,6 +203,7 @@ export const Sidebar = () => {
     currentView, currentCategory,
     setView, setCategory,
     openTaskModal,
+    openHabitModal,
     categories, addCategory, removeCategory, renameCategory, reorderCategories,
     activeWorkspaceId,
   } = useUIStore();
@@ -251,11 +252,25 @@ export const Sidebar = () => {
     [tasks]
   );
 
+  const habitsCount = useMemo(
+    () => {
+      const habitIds = new Set(
+        tasks
+          .filter(t => t.isHabit && !t.isTemplate && t.status !== 'deleted' && t.status !== 'archived')
+          .map(t => t.templateId ?? t.id)
+      );
+      return habitIds.size;
+    },
+    [tasks]
+  );
+
   const tagCounts = useMemo<Map<string, number>>(() => {
     const map = new Map<string, number>();
     for (const t of tasks) {
       if (t.isTemplate) continue;
       if (t.status === "deleted" || t.status === "archived") continue;
+      // For habit instances, count only the root (no templateId) to avoid inflating count per series
+      if (t.isHabit && t.templateId) continue;
       for (const tag of t.tags ?? []) {
         const trimmed = tag.trim();
         if (trimmed) map.set(trimmed, (map.get(trimmed) ?? 0) + 1);
@@ -317,10 +332,22 @@ export const Sidebar = () => {
           Add Task
         </button>
 
+        {/* Add Habit */}
+        <button
+          onClick={() => openHabitModal()}
+          aria-label="Add new habit"
+          className="flex items-center justify-center gap-2 w-full px-4 py-2.5 rounded-xl font-semibold text-sm bg-gradient-to-r from-emerald-500 to-teal-600 text-white hover:shadow-lg hover:shadow-emerald-500/20 transition-all duration-200 cursor-pointer"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+          </svg>
+          Add Habit
+        </button>
+
         {/* Planner button */}
         <button
           onClick={() => setView("planDay" as View)}
-          className={`flex items-center gap-2 w-full px-4 py-2.5 rounded-xl font-semibold text-sm transition-all duration-200 cursor-pointer ${
+          className={`flex items-center justify-center gap-2 w-full px-4 py-2.5 rounded-xl font-semibold text-sm transition-all duration-200 cursor-pointer ${
             currentView === "planDay" || currentView === "planWeek"
               ? "bg-gradient-to-r from-violet-500 to-purple-600 text-white shadow-lg shadow-purple-500/20"
               : "bg-gradient-to-r from-violet-500/80 to-purple-600/80 text-white hover:shadow-lg hover:shadow-purple-500/20"
@@ -383,6 +410,23 @@ export const Sidebar = () => {
               {overdueCount > 0 && (
                 <span className="ml-auto text-xs bg-red-500 text-white rounded-full px-1.5 py-0.5 font-semibold">{overdueCount}</span>
               )}
+            </button>
+          )}
+          {!collapsed["views"] && (
+            <button
+              onClick={() => setView("habits" as View)}
+              aria-label="Go to Habits view"
+              aria-current={currentView === "habits" ? "page" : undefined}
+              className={`flex items-center gap-3 w-full px-3 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
+                currentView === "habits"
+                  ? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400"
+                  : "text-emerald-600/70 hover:text-emerald-600 hover:bg-emerald-500/10"
+              }`}
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+          </svg>
+              Habits
             </button>
           )}
         </div>

--- a/src/app/components/WeekPlanningView.tsx
+++ b/src/app/components/WeekPlanningView.tsx
@@ -89,14 +89,23 @@ const TaskCard = ({ task, dragging }: TaskCardProps) => {
 
   return (
     <div
-      className={`group flex items-start justify-between gap-2 px-3 py-2.5 rounded-xl border bg-card transition-all ${
-        dragging
-          ? "opacity-50 shadow-lg border-primary/40"
-          : "border-border hover:border-border/80 hover:shadow-sm"
+      className={`group flex items-start justify-between gap-2 px-3 py-2.5 rounded-xl border transition-all ${
+        task.isHabit
+          ? dragging
+            ? "opacity-50 shadow-lg border-emerald-500/40 bg-emerald-500/5"
+            : "border-emerald-500/30 bg-emerald-500/5 hover:border-emerald-500/50 hover:shadow-sm"
+          : dragging
+          ? "opacity-50 shadow-lg border-primary/40 bg-card"
+          : "border-border bg-card hover:border-border/80 hover:shadow-sm"
       }`}
     >
       <div className="flex-1 min-w-0">
         <p className="text-sm font-medium text-foreground truncate">{label}</p>
+        {task.isHabit && (
+          <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400 mb-0.5">
+            🔁 Habit
+          </span>
+        )}
         <div className="flex flex-wrap items-center gap-1.5 mt-1">
           {task.category && (
             <span className="text-[11px] px-1.5 py-0.5 rounded-full bg-accent text-muted-foreground font-medium">

--- a/src/app/components/modals/HabitModal.tsx
+++ b/src/app/components/modals/HabitModal.tsx
@@ -1,0 +1,668 @@
+import { useState, useEffect, useRef } from "react";
+import { useTasksStore } from "@/store/tasksStore";
+import { useUIStore } from "@/store/uiStore";
+import { useAuthStore } from "@/store/authStore";
+import { useWorkspaceStore } from "@/store/workspaceStore";
+import { useBodyScrollLock } from "@/hooks/useBodyScrollLock";
+import type { Priority, Repeat, TaskFormState } from "@/store/types";
+
+const PRIORITIES: Priority[] = ["low", "medium", "high"];
+const HABIT_REPEATS: Exclude<Repeat, "none">[] = ["daily", "weekly", "monthly"];
+
+const PRIORITY_LABELS: Record<Priority, string> = {
+  low: "Nice to have",
+  medium: "Should have",
+  high: "Must have",
+};
+
+const PRIORITY_COLORS: Record<Priority, string> = {
+  low: "text-green-600 dark:text-green-400",
+  medium: "text-amber-600 dark:text-amber-400",
+  high: "text-red-600 dark:text-red-400",
+};
+
+const REPEAT_LABELS: Record<Exclude<Repeat, "none">, string> = {
+  daily: "Daily",
+  weekly: "Weekly",
+  monthly: "Monthly",
+};
+
+// ─── Inner form ───────────────────────────────────────────────────────────────
+interface InnerProps {
+  isEditing: boolean;
+  /** True when editing a habit instance (has templateId), not the root habit */
+  isInstance: boolean;
+  /** True when editing all instances as a series */
+  isSeries: boolean;
+  initialForm: TaskFormState;
+  onSubmit: (form: TaskFormState) => Promise<void>;
+  onClose: () => void;
+  categories: { id: string; name: string; color: string }[];
+  workspaces: { id: string; name: string; color: string }[];
+}
+
+const HabitModalInner = ({
+  isEditing,
+  isInstance,
+  isSeries,
+  initialForm,
+  onSubmit,
+  onClose,
+  categories,
+  workspaces,
+}: InnerProps) => {
+  const [form, setForm] = useState<TaskFormState>(initialForm);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const titleRef = useRef<HTMLInputElement>(null);
+
+  // Auto-focus title on mount
+  useEffect(() => {
+    setTimeout(() => titleRef.current?.focus(), 50);
+  }, []);
+
+  const setField = <K extends keyof TaskFormState>(field: K, value: TaskFormState[K]) =>
+    setForm((f) => ({ ...f, [field]: value }));
+
+  const validate = (): boolean => {
+    const e: Record<string, string> = {};
+    if (!form.title.trim()) e.title = "Title is required";
+    if (form.title.length > 150) e.title = "Title too long (max 150 characters)";
+    if (form.description.length > 1000) e.description = "Description too long (max 1000 characters)";
+    if (form.notes.length > 2000) e.notes = "Notes too long (max 2000 characters)";
+    if (!isInstance) {
+      if (!form.startDate) e.startDate = "Start Date is required";
+      if (form.startDate && form.repeatEndDate && form.repeatEndDate < form.startDate) {
+        e.repeatEndDate = "End Date must be on or after Start Date";
+      }
+    }
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validate()) return;
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      await onSubmit(form);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div
+        className="bg-background border border-emerald-500/30 rounded-2xl shadow-2xl w-full max-w-2xl max-h-[92vh] flex flex-col"
+        role="dialog"
+        aria-modal="true"
+        aria-label={isEditing ? "Edit Habit" : "Add Habit"}
+      >
+        {/* Header */}
+        <div className="px-6 py-4 border-b border-border flex items-center justify-between flex-shrink-0">
+          <div>
+            <div className="flex items-center gap-2">
+              <span className="text-lg">🔁</span>
+              <h3 className="text-xl font-bold text-foreground">
+                {isEditing
+                  ? (isInstance ? "Edit Habit Occurrence" : "Edit Habit")
+                  : "Add Habit"}
+              </h3>
+            </div>
+            {isInstance && (
+              <p className="text-xs text-muted-foreground mt-0.5 ml-7">Only description &amp; notes can be set per occurrence</p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close modal"
+            className="p-2 hover:bg-accent rounded-lg transition-colors text-muted-foreground cursor-pointer"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} className="px-6 py-4 space-y-4 overflow-y-auto flex-1">
+
+          {/* ── INSTANCE MODE: only Title (locked) + Description + Notes ── */}
+          {isInstance ? (
+            <>
+              {/* Title — read-only */}
+              <div>
+                <label className="block text-sm font-semibold text-foreground mb-1">Title</label>
+                <div
+                  className="w-full px-3 py-2 text-sm border border-border/50 rounded-lg bg-muted/50 text-muted-foreground"
+                  title="Title is shared across all occurrences of this habit"
+                >
+                  {form.title}
+                </div>
+                <p className="text-xs text-muted-foreground/60 mt-1">Shared across all occurrences — edit the habit series to change it</p>
+              </div>
+
+              {/* Description — series-level, read-only */}
+              {form.description ? (
+                <div>
+                  <label className="block text-sm font-semibold text-foreground mb-1">Description</label>
+                  <div
+                    className="w-full px-3 py-2 text-sm border border-border/50 rounded-lg bg-muted/50 text-muted-foreground"
+                    title="Description is shared across all occurrences"
+                  >
+                    {form.description}
+                  </div>
+                  <p className="text-xs text-muted-foreground/60 mt-1">Shared across all occurrences — edit the habit series to change it</p>
+                </div>
+              ) : null}
+
+              {/* Notes — truly per-occurrence */}
+              <div>
+                <label className="block text-sm font-semibold text-foreground mb-1">
+                  Notes
+                  <span className="ml-1.5 text-xs font-normal text-emerald-500/80">· this occurrence only</span>
+                </label>
+                <textarea
+                  ref={titleRef as unknown as React.RefObject<HTMLTextAreaElement>}
+                  rows={4}
+                  maxLength={2000}
+                  value={form.notes}
+                  onChange={(e) => setField("notes", e.target.value)}
+                  className="w-full px-3 py-2 text-sm border border-input rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-none"
+                  placeholder="Notes specific to this occurrence (e.g. meditated for 15 min)..."
+                />
+                {form.notes.length > 1600 && (
+                  <span className="text-xs text-amber-500">{form.notes.length}/2000</span>
+                )}
+              </div>
+            </>
+          ) : isSeries ? (
+            // ── SERIES MODE: Title, Description, Priority, Workspace, Category ──
+            <>
+              {/* Title */}
+              <div>
+                <label className="block text-sm font-semibold text-foreground mb-1">
+                  Title <span className="text-red-500">*</span>
+                </label>
+                <input
+                  ref={titleRef}
+                  type="text"
+                  required
+                  maxLength={150}
+                  value={form.title}
+                  onChange={(e) => setField("title", e.target.value)}
+                  className={`w-full px-3 py-2 text-sm border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring ${errors.title ? "border-red-500" : "border-input"}`}
+                  placeholder="Habit title..."
+                />
+                <div className="flex justify-between mt-1">
+                  {errors.title ? <p className="text-xs text-red-500">{errors.title}</p> : <span />}
+                  <span className={`text-xs ml-auto ${form.title.length > 130 ? "text-amber-500" : "text-muted-foreground/50"}`}>
+                    {form.title.length}/150
+                  </span>
+                </div>
+              </div>
+
+              {/* Description */}
+              <div>
+                <label className="block text-sm font-semibold text-foreground mb-1">Description</label>
+                <textarea
+                  rows={2}
+                  maxLength={1000}
+                  value={form.description}
+                  onChange={(e) => setField("description", e.target.value)}
+                  className="w-full px-3 py-2 text-sm border border-input rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-none"
+                  placeholder="Optional description..."
+                />
+                {form.description.length > 800 && (
+                  <span className="text-xs text-amber-500">{form.description.length}/1000</span>
+                )}
+              </div>
+
+              {/* Priority */}
+              <div>
+                <label className="block text-sm font-semibold text-foreground mb-1">Priority</label>
+                <select
+                  value={form.priority}
+                  onChange={(e) => setField("priority", e.target.value as Priority)}
+                  className="w-full px-3 pr-8 py-2 text-sm border border-input rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring hover:cursor-pointer"
+                >
+                  {PRIORITIES.map((p) => (
+                    <option key={p} value={p}>{PRIORITY_LABELS[p]}</option>
+                  ))}
+                </select>
+                <div className={`text-xs mt-1 font-medium ${PRIORITY_COLORS[form.priority]}`}>
+                  {PRIORITY_LABELS[form.priority]}
+                </div>
+              </div>
+
+              {/* Workspace + Category */}
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-sm font-semibold text-foreground mb-1">Workspace</label>
+                  <select
+                    value={form.workspace}
+                    onChange={(e) => setField("workspace", e.target.value)}
+                    className="w-full px-3 pr-8 py-2 text-sm border border-input rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring hover:cursor-pointer"
+                  >
+                    <option value="">— None —</option>
+                    {workspaces.map((w) => (
+                      <option key={w.id} value={w.name}>{w.name}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-semibold text-foreground mb-1">Category</label>
+                  <select
+                    value={form.category}
+                    onChange={(e) => setField("category", e.target.value)}
+                    className="w-full px-3 pr-8 py-2 text-sm border border-input rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring hover:cursor-pointer"
+                  >
+                    <option value="">— None —</option>
+                    {categories.map((c) => (
+                      <option key={c.id} value={c.name}>{c.name}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
+              {/* Locked fields info */}
+              <div className="flex items-start gap-2 px-3 py-2.5 rounded-lg bg-muted/40 border border-border/50">
+                <svg className="w-4 h-4 text-muted-foreground flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <p className="text-xs text-muted-foreground">
+                  <span className="font-medium text-foreground">Repeat pattern &amp; dates</span> are locked after creation.
+                  To change them, delete this habit and create a new one.
+                </p>
+              </div>
+            </>
+          ) : (
+            <>
+          {/* Title */}
+          <div>
+            <label className="block text-sm font-semibold text-foreground mb-1">
+              Title <span className="text-red-500">*</span>
+            </label>
+            <input
+              ref={titleRef}
+              type="text"
+              required
+              maxLength={150}
+              value={form.title}
+              onChange={(e) => setField("title", e.target.value)}
+              className={`w-full px-3 py-2 text-sm border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring ${errors.title ? "border-red-500" : "border-input"}`}
+              placeholder="Habit title..."
+            />
+            <div className="flex justify-between mt-1">
+              {errors.title
+                ? <p className="text-xs text-red-500">{errors.title}</p>
+                : <span />}
+              <span className={`text-xs ml-auto ${form.title.length > 130 ? "text-amber-500" : "text-muted-foreground/50"}`}>
+                {form.title.length}/150
+              </span>
+            </div>
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="block text-sm font-semibold text-foreground mb-1">Description</label>
+            <textarea
+              rows={2}
+              maxLength={1000}
+              value={form.description}
+              onChange={(e) => setField("description", e.target.value)}
+              className={`w-full px-3 py-2 text-sm border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-none ${errors.description ? "border-red-500" : "border-input"}`}
+              placeholder="Optional description..."
+            />
+            <div className="flex justify-between mt-1">
+              {errors.description
+                ? <p className="text-xs text-red-500">{errors.description}</p>
+                : <span />}
+              {form.description.length > 800 && (
+                <span className="text-xs ml-auto text-amber-500">{form.description.length}/1000</span>
+              )}
+            </div>
+          </div>
+
+          {/* Row: Repeat (required, no "none") + Priority */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-semibold text-foreground mb-1">
+                Repeat {!isInstance && <span className="text-red-500">*</span>}
+              </label>
+              {isInstance ? (
+                <div className="w-full px-3 py-2 text-sm border border-border/50 rounded-lg bg-muted/50 text-muted-foreground flex items-center justify-between" title="Repeat pattern is set on the habit series and cannot be changed per instance">
+                  <span>{REPEAT_LABELS[form.repeat as Exclude<Repeat, "none">] ?? form.repeat}</span>
+                  <svg className="w-3.5 h-3.5 opacity-50 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                  </svg>
+                </div>
+              ) : (
+                <select
+                  value={form.repeat}
+                  onChange={(e) => setField("repeat", e.target.value as Repeat)}
+                  className="w-full px-3 pr-8 py-2 text-sm border border-emerald-500/40 rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-emerald-500/50 hover:cursor-pointer"
+                >
+                  {HABIT_REPEATS.map((r) => (
+                    <option key={r} value={r}>
+                      {REPEAT_LABELS[r]}
+                    </option>
+                  ))}
+                </select>
+              )}
+              <p className="text-xs text-emerald-500/80 mt-1 font-medium">
+                {isInstance ? "Defined by the habit series" : `${REPEAT_LABELS[form.repeat as Exclude<Repeat, "none">] ?? ""} habit`}
+              </p>
+            </div>
+            <div>
+              <label className="block text-sm font-semibold text-foreground mb-1">Priority</label>
+              <select
+                value={form.priority}
+                onChange={(e) => setField("priority", e.target.value as Priority)}
+                className="w-full px-3 pr-8 py-2 text-sm border border-input rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring hover:cursor-pointer"
+              >
+                {PRIORITIES.map((p) => (
+                  <option className="hover:cursor-pointer" key={p} value={p}>
+                    {PRIORITY_LABELS[p]}
+                  </option>
+                ))}
+              </select>
+              <div className={`text-xs mt-1 font-medium ${PRIORITY_COLORS[form.priority]}`}>
+                {PRIORITY_LABELS[form.priority]}
+              </div>
+            </div>
+          </div>
+
+          {/* Row: Start Date + End Date (or just Instance Date when editing instance) */}
+          {isInstance ? (
+            <div>
+              <label className="block text-sm font-semibold text-foreground mb-1">Instance Date</label>
+              <input
+                type="date"
+                value={form.startDate}
+                onChange={(e) => setField("startDate", e.target.value)}
+                className="w-full px-3 py-2 text-sm border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring border-input"
+              />
+              <p className="text-xs text-muted-foreground mt-1">Date of this specific occurrence</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm font-semibold text-foreground mb-1">
+                  Start Date <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="date"
+                  value={form.startDate}
+                  onChange={(e) => setField("startDate", e.target.value)}
+                  className={`w-full px-3 py-2 text-sm border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring ${errors.startDate ? "border-red-500" : "border-input"}`}
+                />
+                {errors.startDate
+                  ? <p className="text-xs text-red-500 mt-1">{errors.startDate}</p>
+                  : <p className="text-xs text-muted-foreground mt-1">First occurrence</p>}
+              </div>
+              <div>
+                <label className="block text-sm font-semibold text-foreground mb-1">End Date</label>
+                <div className="flex items-center gap-1.5">
+                  <input
+                    type="date"
+                    value={form.repeatEndDate}
+                    min={form.startDate || undefined}
+                    onChange={(e) => setField("repeatEndDate", e.target.value)}
+                    className={`flex-1 px-3 py-2 text-sm border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring ${errors.repeatEndDate ? "border-red-500" : "border-input"}`}
+                  />
+                  {form.repeatEndDate && (
+                    <button
+                      type="button"
+                      onClick={() => setField("repeatEndDate", "")}
+                      className="flex-shrink-0 p-1.5 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors cursor-pointer"
+                      aria-label="Clear end date"
+                    >
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                    </button>
+                  )}
+                </div>
+                {errors.repeatEndDate
+                  ? <p className="text-xs text-red-500 mt-1">{errors.repeatEndDate}</p>
+                  : <p className="text-xs text-muted-foreground mt-1">
+                      {form.repeatEndDate
+                        ? "Instances generated up to end date"
+                        : "Ongoing — instances generated 30 days ahead"}
+                    </p>}
+              </div>
+            </div>
+          )}
+
+          {/* Row: Workspace + Category */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-semibold text-foreground mb-1">Workspace</label>
+              {isInstance ? (
+                <div className="w-full px-3 py-2 text-sm border border-border/50 rounded-lg bg-muted/50 text-muted-foreground flex items-center justify-between" title="Workspace is set on the habit series">
+                  <span>{form.workspace || "— None —"}</span>
+                  <svg className="w-3.5 h-3.5 opacity-50 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                  </svg>
+                </div>
+              ) : (
+                <select
+                  value={form.workspace}
+                  onChange={(e) => setField("workspace", e.target.value)}
+                  className="w-full px-3 pr-8 py-2 text-sm border border-input rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring hover:cursor-pointer"
+                >
+                  <option value="">— None —</option>
+                  {workspaces.map((w) => (
+                    <option key={w.id} value={w.name}>{w.name}</option>
+                  ))}
+                </select>
+              )}
+            </div>
+            <div>
+              <label className="block text-sm font-semibold text-foreground mb-1">Category</label>
+              {isInstance ? (
+                <div className="w-full px-3 py-2 text-sm border border-border/50 rounded-lg bg-muted/50 text-muted-foreground flex items-center justify-between" title="Category is set on the habit series">
+                  <span>{form.category || "— None —"}</span>
+                  <svg className="w-3.5 h-3.5 opacity-50 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                  </svg>
+                </div>
+              ) : (
+                <select
+                  value={form.category}
+                  onChange={(e) => setField("category", e.target.value)}
+                  className="w-full px-3 pr-8 py-2 text-sm border border-input rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring hover:cursor-pointer"
+                >
+                  <option value="">— None —</option>
+                  {categories.map((c) => (
+                    <option key={c.id} value={c.name}>{c.name}</option>
+                  ))}
+                </select>
+              )}
+            </div>
+          </div>
+
+          {/* Notes */}
+          <div>
+            <label className="block text-sm font-semibold text-foreground mb-1">Notes</label>
+            <textarea
+              rows={2}
+              maxLength={2000}
+              value={form.notes}
+              onChange={(e) => setField("notes", e.target.value)}
+              className={`w-full px-3 py-2 text-sm border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-none ${errors.notes ? "border-red-500" : "border-input"}`}
+              placeholder="Additional notes..."
+            />
+            <div className="flex justify-between mt-1">
+              {errors.notes
+                ? <p className="text-xs text-red-500">{errors.notes}</p>
+                : <span />}
+              {form.notes.length > 1600 && (
+                <span className="text-xs ml-auto text-amber-500">{form.notes.length}/2000</span>
+              )}
+            </div>
+          </div>
+
+          </>
+          )}
+
+          {/* Actions */}
+          <div className="flex gap-2 pt-2 pb-1">
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="flex-1 px-4 py-2.5 bg-gradient-to-r from-emerald-600 to-emerald-700 text-white rounded-lg font-semibold hover:shadow-lg hover:shadow-emerald-500/20 transition-all duration-200 cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            >
+              {isSubmitting && (
+                <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4l3-3-3-3V0a12 12 0 00-12 12h4z" />
+                </svg>
+              )}
+              {isSubmitting ? (isEditing ? "Saving…" : "Creating…") : (isEditing ? "Save Changes" : "Create Habit")}
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2.5 bg-muted text-muted-foreground rounded-lg font-semibold hover:bg-accent transition-colors cursor-pointer"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+// ─── HabitModal (outer shell) ─────────────────────────────────────────────────
+export const HabitModal = () => {
+  const { addTaskRich, updateTaskRich, tasks } = useTasksStore();
+  const { modals, editingTask, closeAllModals, showNotification, categories, activeWorkspaceId, habitEditMode } = useUIStore();
+  const { user } = useAuthStore();
+  const { workspaces, activeWorkspaceId: wsStoreActiveId } = useWorkspaceStore();
+  const isOpen = modals.habit;
+
+  useBodyScrollLock(isOpen);
+
+  if (!isOpen) return null;
+
+  const resolvedWsId = activeWorkspaceId ?? wsStoreActiveId;
+  const activeWorkspaceName = workspaces.find((w) => w.id === resolvedWsId)?.name ?? workspaces[0]?.name ?? "";
+
+  // Resolve live editing task from store
+  const liveEditingTask = editingTask
+    ? (tasks.find((t) => t.id === editingTask.id) ?? editingTask)
+    : null;
+
+  const EMPTY: TaskFormState = {
+    title: "",
+    description: "",
+    dueDate: "",
+    startDate: "",
+    repeatEndDate: "",
+    priority: "medium",
+    workspace: activeWorkspaceName,
+    category: categories[0]?.name ?? "",
+    repeat: "daily",
+    tags: "",
+    notes: "",
+    subtasks: [],
+  };
+
+  const initialForm: TaskFormState = liveEditingTask
+    ? {
+        title: liveEditingTask.title ?? liveEditingTask.text ?? "",
+        description: liveEditingTask.description ?? "",
+        dueDate: "",
+        startDate: liveEditingTask.startDate ?? liveEditingTask.dueDate ?? "",
+        repeatEndDate: liveEditingTask.repeatEndDate ?? "",
+        priority: liveEditingTask.priority ?? "medium",
+        workspace: liveEditingTask.workspace ?? (workspaces[0]?.name ?? ""),
+        category: liveEditingTask.category ?? (categories[0]?.name ?? ""),
+        repeat: (liveEditingTask.repeat && liveEditingTask.repeat !== "none")
+          ? liveEditingTask.repeat
+          : "daily",
+        tags: liveEditingTask.tags ? liveEditingTask.tags.join(", ") : "",
+        notes: liveEditingTask.notes ?? "",
+        subtasks: liveEditingTask.subtasks ? [...liveEditingTask.subtasks] : [],
+      }
+    : EMPTY;
+
+  // 'series' = edit all instances, 'instance' = edit one occurrence, null = create new
+  const isInstance = habitEditMode === 'instance';
+  const isSeries   = habitEditMode === 'series';
+
+  const handleSubmit = async (form: TaskFormState) => {
+    closeAllModals();
+    try {
+      if (liveEditingTask) {
+        if (isSeries) {
+          // Series edit — propagate title, description, priority, workspace, category
+          // to ALL non-deleted instances of this habit series
+          const habitId = liveEditingTask.templateId ?? liveEditingTask.id;
+          const allInstances = tasks.filter(
+            t => t.isHabit && !t.deletedAt &&
+              (t.id === habitId || t.templateId === habitId)
+          );
+          const seriesUpdates: Partial<import('@/store/tasksStore').Task> = {
+            title:       form.title,
+            text:        form.title,
+            description: form.description || undefined,
+            priority:    form.priority,
+            workspace:   form.workspace || undefined,
+            category:    form.category || undefined,
+          };
+          await Promise.all(
+            allInstances.map(t => updateTaskRich(t.id, seriesUpdates, user?.id))
+          );
+          showNotification(`Habit series updated (${allInstances.length} occurrences)`, 'success');
+        } else if (isInstance) {
+          // Instance edit — only notes are truly per-occurrence.
+          // description lives on the root task (series-level) so we never overwrite it here.
+          await updateTaskRich(
+            liveEditingTask.id,
+            {
+              notes: form.notes || undefined,
+            },
+            user?.id,
+          );
+          showNotification('Habit occurrence updated!', 'success');
+        } else {
+          // Should not happen (create goes through addTaskRich below), safety fallback
+          showNotification('Nothing to update', 'info');
+        }
+      } else {
+        await addTaskRich(form, user?.id);
+        showNotification('Habit created!', 'success');
+      }
+    } catch {
+      showNotification('Failed to save habit. Please try again.', 'error');
+    }
+  };
+
+  const habitKey = liveEditingTask
+    ? `habit__${liveEditingTask.id}__${habitEditMode}`
+    : `new_habit__${isOpen}`;
+
+  return (
+    <HabitModalInner
+      key={habitKey}
+      isEditing={!!liveEditingTask}
+      isInstance={isInstance}
+      isSeries={isSeries}
+      initialForm={initialForm}
+      onSubmit={handleSubmit}
+      onClose={closeAllModals}
+      categories={categories}
+      workspaces={workspaces}
+    />
+  );
+};

--- a/src/app/components/modals/TaskModal.tsx
+++ b/src/app/components/modals/TaskModal.tsx
@@ -184,10 +184,13 @@ const TaskModalInner = ({
     if (form.title.length > 150) e.title = "Title too long (max 150 characters)";
     if (form.description.length > 1000) e.description = "Description too long (max 1000 characters)";
     if (form.notes.length > 2000) e.notes = "Notes too long (max 2000 characters)";
-    // Repeat requires due date
-    const hasDue = !!form.dueDate;
-    if (form.repeat !== "none" && !hasDue) {
-      e.dueDate = "Due Date required when Repeat is set";
+    if (form.repeat !== "none") {
+      if (!form.startDate) {
+        e.startDate = "Start Date is required when Repeat is set";
+      }
+      if (form.startDate && form.repeatEndDate && form.repeatEndDate < form.startDate) {
+        e.repeatEndDate = "End Date must be on or after Start Date";
+      }
     }
     setErrors(e);
     return Object.keys(e).length === 0;
@@ -282,7 +285,8 @@ const TaskModalInner = ({
             </div>
           </div>
 
-          {/* Due Date */}
+          {/* Due Date — hidden when repeat is active (auto-set per instance) */}
+          {form.repeat === "none" && (
           <div>
             <label className="block text-sm font-semibold text-foreground mb-1">Due Date</label>
             <div className="flex items-center gap-2">
@@ -307,6 +311,54 @@ const TaskModalInner = ({
             </div>
             {errors.dueDate && <p className="text-xs text-red-500 mt-1">{errors.dueDate}</p>}
           </div>
+          )}
+
+          {/* Start Date + End Date — only when repeat is active */}
+          {form.repeat !== "none" && (
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-semibold text-foreground mb-1">
+                Start Date <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="date"
+                value={form.startDate}
+                onChange={(e) => setField("startDate", e.target.value)}
+                className={`w-full px-3 py-2 text-sm border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring ${errors.startDate ? "border-red-500" : "border-input"}`}
+              />
+              {errors.startDate
+                ? <p className="text-xs text-red-500 mt-1">{errors.startDate}</p>
+                : <p className="text-xs text-muted-foreground mt-1">First occurrence</p>}
+            </div>
+            <div>
+              <label className="block text-sm font-semibold text-foreground mb-1">End Date</label>
+              <div className="flex items-center gap-1.5">
+                <input
+                  type="date"
+                  value={form.repeatEndDate}
+                  min={form.startDate || undefined}
+                  onChange={(e) => setField("repeatEndDate", e.target.value)}
+                  className={`flex-1 px-3 py-2 text-sm border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring ${errors.repeatEndDate ? "border-red-500" : "border-input"}`}
+                />
+                {form.repeatEndDate && (
+                  <button
+                    type="button"
+                    onClick={() => setField("repeatEndDate", "")}
+                    className="flex-shrink-0 p-1.5 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors cursor-pointer"
+                    aria-label="Clear end date"
+                  >
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                )}
+              </div>
+              {errors.repeatEndDate
+                ? <p className="text-xs text-red-500 mt-1">{errors.repeatEndDate}</p>
+                : <p className="text-xs text-muted-foreground mt-1">Empty = repeats forever</p>}
+            </div>
+          </div>
+          )}
 
           {/* Row: Workspace + Category */}
           <div className="grid grid-cols-2 gap-3">
@@ -371,7 +423,7 @@ const TaskModalInner = ({
                 ))}
               </select>
               {form.repeat !== "none" && (
-                <p className="text-xs text-amber-500 mt-1">Start & Due Date required</p>
+                <p className="text-xs text-primary/70 mt-1">Set Start Date below ↓</p>
               )}
             </div>
           </div>
@@ -551,6 +603,8 @@ export const TaskModal = () => {
     title: "",
     description: "",
     dueDate: "",
+    startDate: "",
+    repeatEndDate: "",
     priority: "medium",
     workspace: activeWorkspaceName,
     category: categories[0]?.name ?? "",
@@ -569,6 +623,8 @@ export const TaskModal = () => {
         title: prefillSource.title ?? prefillSource.text ?? "",
         description: prefillSource.description ?? "",
         dueDate: prefillSource.dueDate ?? "",
+        startDate: prefillSource.startDate ?? "",
+        repeatEndDate: prefillSource.repeatEndDate ?? "",
         priority: prefillSource.priority ?? "medium",
         workspace: prefillSource.workspace ?? (workspaces[0]?.name ?? ""),
         category: prefillSource.category ?? (categories[0]?.name ?? ""),
@@ -595,6 +651,8 @@ export const TaskModal = () => {
             workspace: form.workspace || undefined,
             category: form.category || undefined,
             repeat: form.repeat,
+            startDate: form.repeat !== "none" ? (form.startDate || undefined) : undefined,
+            repeatEndDate: form.repeat !== "none" ? (form.repeatEndDate || undefined) : undefined,
             tags: form.tags.split(",").map((t) => t.trim()).filter(Boolean),
             notes: form.notes || undefined,
             subtasks: form.subtasks,

--- a/src/app/components/modals/TaskModal.tsx
+++ b/src/app/components/modals/TaskModal.tsx
@@ -19,10 +19,9 @@ import { useUIStore } from "@/store/uiStore";
 import { useAuthStore } from "@/store/authStore";
 import { useWorkspaceStore } from "@/store/workspaceStore";
 import { useBodyScrollLock } from "@/hooks/useBodyScrollLock";
-import type { Priority, Repeat, TaskFormState, Subtask } from "@/store/types";
+import type { Priority, TaskFormState, Subtask } from "@/store/types";
 
 const PRIORITIES: Priority[] = ["low", "medium", "high"];
-const REPEATS: Repeat[] = ["none", "daily", "weekly", "monthly"];
 
 const PRIORITY_LABELS: Record<Priority, string> = {
   low: "Nice to have",
@@ -148,9 +147,11 @@ const TaskModalInner = ({
     .map((t) => t.trim())
     .filter(Boolean);
 
+  const MAX_TAGS = 5;
+
   const addTag = () => {
     const trimmed = tagInput.trim().replace(/^#/, "");
-    if (!trimmed || tagList.includes(trimmed)) { setTagInput(""); return; }
+    if (!trimmed || tagList.includes(trimmed) || tagList.length >= MAX_TAGS) { setTagInput(""); return; }
     setField("tags", [...tagList, trimmed].join(", "));
     setTagInput("");
   };
@@ -184,11 +185,6 @@ const TaskModalInner = ({
     if (form.title.length > 150) e.title = "Title too long (max 150 characters)";
     if (form.description.length > 1000) e.description = "Description too long (max 1000 characters)";
     if (form.notes.length > 2000) e.notes = "Notes too long (max 2000 characters)";
-    // Repeat requires due date
-    const hasDue = !!form.dueDate;
-    if (form.repeat !== "none" && !hasDue) {
-      e.dueDate = "Due Date required when Repeat is set";
-    }
     setErrors(e);
     return Object.keys(e).length === 0;
   };
@@ -282,32 +278,50 @@ const TaskModalInner = ({
             </div>
           </div>
 
-          {/* Due Date */}
-          <div>
-            <label className="block text-sm font-semibold text-foreground mb-1">Due Date</label>
-            <div className="flex items-center gap-2">
-              <input
-                type="date"
-                value={form.dueDate}
-                onChange={(e) => setField("dueDate", e.target.value)}
-                className={`w-full max-w-[180px] px-3 py-2 text-sm border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring ${errors.dueDate ? "border-red-500" : "border-input"}`}
-              />
-              {form.dueDate && (
-                <button
-                  type="button"
-                  onClick={() => setField("dueDate", "")}
-                  className="flex-shrink-0 p-1.5 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors cursor-pointer"
-                  aria-label="Clear due date"
-                >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                </button>
-              )}
+          {/* Row: Due Date + Priority */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-semibold text-foreground mb-1">Due Date</label>
+              <div className="flex items-center gap-2">
+                <input
+                  type="date"
+                  value={form.dueDate}
+                  onChange={(e) => setField("dueDate", e.target.value)}
+                  className={`w-full px-3 py-2 text-sm border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring ${errors.dueDate ? "border-red-500" : "border-input"}`}
+                />
+                {form.dueDate && (
+                  <button
+                    type="button"
+                    onClick={() => setField("dueDate", "")}
+                    className="flex-shrink-0 p-1.5 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors cursor-pointer"
+                    aria-label="Clear due date"
+                  >
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                )}
+              </div>
+              {errors.dueDate && <p className="text-xs text-red-500 mt-1">{errors.dueDate}</p>}
             </div>
-            {errors.dueDate && <p className="text-xs text-red-500 mt-1">{errors.dueDate}</p>}
+            <div>
+              <label className="block text-sm font-semibold text-foreground mb-1">Priority</label>
+              <select
+                value={form.priority}
+                onChange={(e) => setField("priority", e.target.value as Priority)}
+                className="w-full px-3 pr-8 py-2 text-sm border border-input rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring hover:cursor-pointer"
+              >
+                {PRIORITIES.map((p) => (
+                  <option className="hover:cursor-pointer" key={p} value={p}>
+                    {PRIORITY_LABELS[p]}
+                  </option>
+                ))}
+              </select>
+              <div className={`text-xs mt-1 font-medium ${PRIORITY_COLORS[form.priority]}`}>
+                {PRIORITY_LABELS[form.priority]}
+              </div>
+            </div>
           </div>
-
           {/* Row: Workspace + Category */}
           <div className="grid grid-cols-2 gap-3">
             <div>
@@ -338,47 +352,14 @@ const TaskModalInner = ({
             </div>
           </div>
 
-          {/* Row: Priority + Repeat */}
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="block text-sm font-semibold text-foreground mb-1">Priority</label>
-              <select
-                value={form.priority}
-                onChange={(e) => setField("priority", e.target.value as Priority)}
-                className="w-full px-3 pr-8 py-2 text-sm border border-input rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring hover:cursor-pointer"
-              >
-                {PRIORITIES.map((p) => (
-                  <option className="hover:cursor-pointer" key={p} value={p}>
-                    {PRIORITY_LABELS[p]}
-                  </option>
-                ))}
-              </select>
-              <div className={`text-xs mt-1 font-medium ${PRIORITY_COLORS[form.priority]}`}>
-                {PRIORITY_LABELS[form.priority]}
-              </div>
-            </div>
-            <div>
-              <label className="block text-sm font-semibold text-foreground mb-1">Repeat</label>
-              <select
-                value={form.repeat}
-                onChange={(e) => setField("repeat", e.target.value as Repeat)}
-                className="w-full px-3 pr-8 py-2 text-sm border border-input rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring hover:cursor-pointer"
-              >
-                {REPEATS.map((r) => (
-                  <option key={r} value={r}>
-                    {r.charAt(0).toUpperCase() + r.slice(1)}
-                  </option>
-                ))}
-              </select>
-              {form.repeat !== "none" && (
-                <p className="text-xs text-amber-500 mt-1">Start & Due Date required</p>
-              )}
-            </div>
-          </div>
-
           {/* Tags */}
           <div>
-            <label className="block text-sm font-semibold text-foreground mb-1">Tags</label>
+            <div className="flex items-center justify-between mb-1">
+              <label className="text-sm font-semibold text-foreground">Tags</label>
+              <span className={`text-xs ${tagList.length >= MAX_TAGS ? "text-amber-500" : "text-muted-foreground/50"}`}>
+                {tagList.length}/{MAX_TAGS}
+              </span>
+            </div>
             {/* Tag chips */}
             {tagList.length > 0 && (
               <div className="flex flex-wrap gap-1.5 mb-2">
@@ -401,27 +382,31 @@ const TaskModalInner = ({
                 ))}
               </div>
             )}
-            <div className="flex gap-2">
-              <input
-                type="text"
-                value={tagInput}
-                onChange={(e) => setTagInput(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") { e.preventDefault(); addTag(); }
-                  if (e.key === ",") { e.preventDefault(); addTag(); }
-                }}
-                maxLength={30}
-                placeholder="Type a tag and press Enter…"
-                className="flex-1 px-3 py-2 text-sm border border-input rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-              />
-              <button
-                type="button"
-                onClick={addTag}
-                className="px-3 py-2 bg-primary/10 text-primary rounded-lg hover:bg-primary/20 transition-colors text-sm font-medium cursor-pointer"
-              >
-                + Add
-              </button>
-            </div>
+            {tagList.length < MAX_TAGS ? (
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={tagInput}
+                  onChange={(e) => setTagInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") { e.preventDefault(); addTag(); }
+                    if (e.key === ",") { e.preventDefault(); addTag(); }
+                  }}
+                  maxLength={30}
+                  placeholder="Type a tag and press Enter…"
+                  className="flex-1 px-3 py-2 text-sm border border-input rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+                <button
+                  type="button"
+                  onClick={addTag}
+                  className="px-3 py-2 bg-primary/10 text-primary rounded-lg hover:bg-primary/20 transition-colors text-sm font-medium cursor-pointer"
+                >
+                  + Add
+                </button>
+              </div>
+            ) : (
+              <p className="text-xs text-amber-500">Maximum of {MAX_TAGS} tags reached.</p>
+            )}
           </div>
 
           {/* Notes */}
@@ -551,6 +536,8 @@ export const TaskModal = () => {
     title: "",
     description: "",
     dueDate: "",
+    startDate: "",
+    repeatEndDate: "",
     priority: "medium",
     workspace: activeWorkspaceName,
     category: categories[0]?.name ?? "",
@@ -569,10 +556,12 @@ export const TaskModal = () => {
         title: prefillSource.title ?? prefillSource.text ?? "",
         description: prefillSource.description ?? "",
         dueDate: prefillSource.dueDate ?? "",
+        startDate: "",
+        repeatEndDate: "",
         priority: prefillSource.priority ?? "medium",
         workspace: prefillSource.workspace ?? (workspaces[0]?.name ?? ""),
         category: prefillSource.category ?? (categories[0]?.name ?? ""),
-        repeat: prefillSource.repeat ?? "none",
+        repeat: "none",
         tags: prefillSource.tags ? prefillSource.tags.join(", ") : "",
         notes: prefillSource.notes ?? "",
         subtasks: prefillSource.subtasks ? [...prefillSource.subtasks] : [],
@@ -590,11 +579,13 @@ export const TaskModal = () => {
             text: form.title,
             description: form.description || undefined,
             dueDate: form.dueDate || undefined,
+            startDate: undefined,
+            repeatEndDate: undefined,
             // overdue is auto-resolved by updateTaskRich based on dueDate
             priority: form.priority,
             workspace: form.workspace || undefined,
             category: form.category || undefined,
-            repeat: form.repeat,
+            repeat: "none" as const,
             tags: form.tags.split(",").map((t) => t.trim()).filter(Boolean),
             notes: form.notes || undefined,
             subtasks: form.subtasks,

--- a/src/app/components/modals/TaskModal.tsx
+++ b/src/app/components/modals/TaskModal.tsx
@@ -184,13 +184,10 @@ const TaskModalInner = ({
     if (form.title.length > 150) e.title = "Title too long (max 150 characters)";
     if (form.description.length > 1000) e.description = "Description too long (max 1000 characters)";
     if (form.notes.length > 2000) e.notes = "Notes too long (max 2000 characters)";
-    if (form.repeat !== "none") {
-      if (!form.startDate) {
-        e.startDate = "Start Date is required when Repeat is set";
-      }
-      if (form.startDate && form.repeatEndDate && form.repeatEndDate < form.startDate) {
-        e.repeatEndDate = "End Date must be on or after Start Date";
-      }
+    // Repeat requires due date
+    const hasDue = !!form.dueDate;
+    if (form.repeat !== "none" && !hasDue) {
+      e.dueDate = "Due Date required when Repeat is set";
     }
     setErrors(e);
     return Object.keys(e).length === 0;
@@ -285,8 +282,7 @@ const TaskModalInner = ({
             </div>
           </div>
 
-          {/* Due Date — hidden when repeat is active (auto-set per instance) */}
-          {form.repeat === "none" && (
+          {/* Due Date */}
           <div>
             <label className="block text-sm font-semibold text-foreground mb-1">Due Date</label>
             <div className="flex items-center gap-2">
@@ -311,54 +307,6 @@ const TaskModalInner = ({
             </div>
             {errors.dueDate && <p className="text-xs text-red-500 mt-1">{errors.dueDate}</p>}
           </div>
-          )}
-
-          {/* Start Date + End Date — only when repeat is active */}
-          {form.repeat !== "none" && (
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="block text-sm font-semibold text-foreground mb-1">
-                Start Date <span className="text-red-500">*</span>
-              </label>
-              <input
-                type="date"
-                value={form.startDate}
-                onChange={(e) => setField("startDate", e.target.value)}
-                className={`w-full px-3 py-2 text-sm border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring ${errors.startDate ? "border-red-500" : "border-input"}`}
-              />
-              {errors.startDate
-                ? <p className="text-xs text-red-500 mt-1">{errors.startDate}</p>
-                : <p className="text-xs text-muted-foreground mt-1">First occurrence</p>}
-            </div>
-            <div>
-              <label className="block text-sm font-semibold text-foreground mb-1">End Date</label>
-              <div className="flex items-center gap-1.5">
-                <input
-                  type="date"
-                  value={form.repeatEndDate}
-                  min={form.startDate || undefined}
-                  onChange={(e) => setField("repeatEndDate", e.target.value)}
-                  className={`flex-1 px-3 py-2 text-sm border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring ${errors.repeatEndDate ? "border-red-500" : "border-input"}`}
-                />
-                {form.repeatEndDate && (
-                  <button
-                    type="button"
-                    onClick={() => setField("repeatEndDate", "")}
-                    className="flex-shrink-0 p-1.5 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors cursor-pointer"
-                    aria-label="Clear end date"
-                  >
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                  </button>
-                )}
-              </div>
-              {errors.repeatEndDate
-                ? <p className="text-xs text-red-500 mt-1">{errors.repeatEndDate}</p>
-                : <p className="text-xs text-muted-foreground mt-1">Empty = repeats forever</p>}
-            </div>
-          </div>
-          )}
 
           {/* Row: Workspace + Category */}
           <div className="grid grid-cols-2 gap-3">
@@ -423,7 +371,7 @@ const TaskModalInner = ({
                 ))}
               </select>
               {form.repeat !== "none" && (
-                <p className="text-xs text-primary/70 mt-1">Set Start Date below ↓</p>
+                <p className="text-xs text-amber-500 mt-1">Start & Due Date required</p>
               )}
             </div>
           </div>
@@ -603,8 +551,6 @@ export const TaskModal = () => {
     title: "",
     description: "",
     dueDate: "",
-    startDate: "",
-    repeatEndDate: "",
     priority: "medium",
     workspace: activeWorkspaceName,
     category: categories[0]?.name ?? "",
@@ -623,8 +569,6 @@ export const TaskModal = () => {
         title: prefillSource.title ?? prefillSource.text ?? "",
         description: prefillSource.description ?? "",
         dueDate: prefillSource.dueDate ?? "",
-        startDate: prefillSource.startDate ?? "",
-        repeatEndDate: prefillSource.repeatEndDate ?? "",
         priority: prefillSource.priority ?? "medium",
         workspace: prefillSource.workspace ?? (workspaces[0]?.name ?? ""),
         category: prefillSource.category ?? (categories[0]?.name ?? ""),
@@ -651,8 +595,6 @@ export const TaskModal = () => {
             workspace: form.workspace || undefined,
             category: form.category || undefined,
             repeat: form.repeat,
-            startDate: form.repeat !== "none" ? (form.startDate || undefined) : undefined,
-            repeatEndDate: form.repeat !== "none" ? (form.repeatEndDate || undefined) : undefined,
             tags: form.tags.split(",").map((t) => t.trim()).filter(Boolean),
             notes: form.notes || undefined,
             subtasks: form.subtasks,

--- a/src/app/components/statistics/StatisticsPage.tsx
+++ b/src/app/components/statistics/StatisticsPage.tsx
@@ -165,7 +165,7 @@ export default function StatisticsPage() {
     return Array.from({ length: days }, (_, i) => {
       const day = i + 1;
       const dateStr = `${prefix}-${String(day).padStart(2, "0")}`;
-      const nonTemplates = tasks.filter((t) => !t.isTemplate);
+      const nonTemplates = tasks.filter((t) => !t.isTemplate && !t.isHabit);
 
       return {
         label: String(day),
@@ -183,7 +183,7 @@ export default function StatisticsPage() {
   const yearlyData = useMemo((): ChartEntry[] => {
     return MONTHS_SHORT.map((monthLabel, mi) => {
       const prefix = `${selectedYear}-${String(mi + 1).padStart(2, "0")}`;
-      const nonTemplates = tasks.filter((t) => !t.isTemplate);
+      const nonTemplates = tasks.filter((t) => !t.isTemplate && !t.isHabit);
 
       return {
         label: monthLabel,
@@ -208,7 +208,7 @@ export default function StatisticsPage() {
   const completionRate = totalCreated > 0 ? Math.round((totalCompleted / totalCreated) * 100) : 0;
 
   // ── Pie chart — task status breakdown (all time) ──────────────────────────
-  const nonTemplates = tasks.filter((t) => !t.isTemplate);
+  const nonTemplates = tasks.filter((t) => !t.isTemplate && !t.isHabit);
   const pieData = [
     { name: "Active",    value: nonTemplates.filter((t) => t.status === "active" || t.status === "inProgress").length,    fill: PALETTE.created },
     { name: "Completed", value: nonTemplates.filter((t) => t.status === "completed").length, fill: PALETTE.completed },

--- a/src/app/components/tasks/TaskItem.tsx
+++ b/src/app/components/tasks/TaskItem.tsx
@@ -4,7 +4,56 @@ import { useUIStore } from "@/store/uiStore";
 import { useAuthStore } from "@/store/authStore";
 import type { Subtask } from "@/store/types";
 
-// ── Badge helpers ────────────────────────────────────────────────────────────
+// ── HabitDeleteDialog: 3-option dialog for deleting habit instances ──────────
+interface HabitDeleteDialogProps {
+  onClose: () => void;
+  onConfirm: (mode: 'this' | 'future' | 'all') => void;
+}
+
+const HabitDeleteDialog = ({ onClose, onConfirm }: HabitDeleteDialogProps) => {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="bg-card border border-border rounded-2xl shadow-xl p-6 w-full max-w-sm mx-4">
+        <h3 className="text-base font-bold text-foreground mb-1">Delete repeating habit</h3>
+        <p className="text-sm text-muted-foreground mb-5">
+          This task is part of a habit series. Which occurrences do you want to delete?
+        </p>
+        <div className="flex flex-col gap-2">
+          <button
+            onClick={() => onConfirm('this')}
+            className="w-full px-4 py-2.5 rounded-xl text-sm font-medium text-left border border-border hover:bg-accent transition-colors"
+          >
+            <span className="font-semibold text-foreground">This one only</span>
+            <span className="block text-xs text-muted-foreground mt-0.5">Delete only this specific occurrence</span>
+          </button>
+          <button
+            onClick={() => onConfirm('future')}
+            className="w-full px-4 py-2.5 rounded-xl text-sm font-medium text-left border border-border hover:bg-accent transition-colors"
+          >
+            <span className="font-semibold text-foreground">This and all following</span>
+            <span className="block text-xs text-muted-foreground mt-0.5">Delete this and all future occurrences</span>
+          </button>
+          <button
+            onClick={() => onConfirm('all')}
+            className="w-full px-4 py-2.5 rounded-xl text-sm font-medium text-left border border-red-500/30 hover:bg-red-500/10 transition-colors"
+          >
+            <span className="font-semibold text-red-500 dark:text-red-400">All occurrences</span>
+            <span className="block text-xs text-muted-foreground mt-0.5">Delete the entire habit and all its instances</span>
+          </button>
+        </div>
+        <button
+          onClick={onClose}
+          className="mt-4 w-full px-4 py-2 rounded-xl text-sm text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+};
 
 const PRIORITY_BADGE: Record<string, string> = {
   low: "bg-green-900/60 text-green-300 border border-green-700/40",
@@ -56,9 +105,12 @@ interface TaskItemProps {
 }
 
 export const TaskItem = ({ task }: TaskItemProps) => {
-  const { markAsCompleted, deleteTask, undoTask, updateTaskRich, retryTask } = useTasksStore();
-  const { toggleTaskSelect, selectedTasks, openTaskModal, showNotification, categories } = useUIStore();
+  const { markAsCompleted, deleteTask, undoTask, updateTaskRich, retryTask, deleteHabitInstances } = useTasksStore();
+  const { toggleTaskSelect, selectedTasks, openTaskModal, openHabitModal, showNotification, categories } = useUIStore();
   const { user } = useAuthStore();
+
+  // Habit delete dialog state
+  const [habitDeleteOpen, setHabitDeleteOpen] = useState(false);
 
   // Resolve category badge class from live category list
   const getCategoryBadge = (categoryName: string) => {
@@ -90,13 +142,32 @@ export const TaskItem = ({ task }: TaskItemProps) => {
         setCompleteAnim("done");
         await markAsCompleted(task.id, user?.id);
         showNotification("Task completed!", "success");
+        // For habit instances the item stays in the list — reset the animation
+        // so the completed state (strikethrough, dimmed) renders correctly
+        if (task.isHabit) {
+          setTimeout(() => setCompleteAnim("idle"), 400);
+        }
       }, 500);
     }
   }, [isCompleted, task.id, user?.id, markAsCompleted, undoTask, showNotification]);
 
   const handleDelete = async () => {
+    if (task.isHabit) {
+      setHabitDeleteOpen(true);
+      return;
+    }
     await deleteTask(task.id, user?.id);
     showNotification("Task deleted", "warning");
+  };
+
+  const handleHabitDeleteConfirm = async (mode: 'this' | 'future' | 'all') => {
+    setHabitDeleteOpen(false);
+    const habitId = task.templateId ?? task.id;
+    await deleteHabitInstances(habitId, mode, task.id, task.dueDate, user?.id);
+    showNotification(
+      mode === 'this' ? 'Habit occurrence deleted' : mode === 'future' ? 'This and future occurrences deleted' : 'Entire habit deleted',
+      'warning',
+    );
   };
 
   // Toggle a subtask's completed state inline (no modal needed)
@@ -108,8 +179,15 @@ export const TaskItem = ({ task }: TaskItemProps) => {
   };
 
   return (
+    <>
+    {habitDeleteOpen && (
+      <HabitDeleteDialog
+        onClose={() => setHabitDeleteOpen(false)}
+        onConfirm={handleHabitDeleteConfirm}
+      />
+    )}
     <div
-      onDoubleClick={() => openTaskModal(task)}
+      onDoubleClick={() => task.isHabit ? openHabitModal(task) : openTaskModal(task)}
       style={{
         // Fade-out when marking complete
         opacity: completeAnim === "done" ? 0 : 1,
@@ -188,6 +266,13 @@ export const TaskItem = ({ task }: TaskItemProps) => {
 
         {/* Badges row */}
         <div className="flex flex-wrap gap-1.5 mt-1.5">
+          {/* Habit badge */}
+          {task.isHabit && (
+            <span className="text-[11px] px-1.5 py-0.5 rounded-full font-medium bg-emerald-900/60 text-emerald-300 border border-emerald-700/40">
+              🔁 Habit
+            </span>
+          )}
+
           {/* Priority */}
           {task.priority && (
             <span className={`text-[11px] px-1.5 py-0.5 rounded-full font-medium ${PRIORITY_BADGE[task.priority] ?? ""}`}>
@@ -294,10 +379,10 @@ export const TaskItem = ({ task }: TaskItemProps) => {
       </div>
 
       {/* Right-side action bar — always visible on hover, complete btn included */}
-      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0 mt-0.5">
+      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 [@media(hover:none)]:opacity-100 transition-opacity flex-shrink-0 mt-0.5">
         {/* Edit */}
         <button
-          onClick={(e) => { e.stopPropagation(); openTaskModal(task); }}
+          onClick={(e) => { e.stopPropagation(); task.isHabit ? openHabitModal(task) : openTaskModal(task); }}
           className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
           aria-label="Edit task"
         >
@@ -347,6 +432,7 @@ export const TaskItem = ({ task }: TaskItemProps) => {
         </button>
       </div>
     </div>
+    </>
   );
 };
 

--- a/src/app/components/tasks/TaskList.tsx
+++ b/src/app/components/tasks/TaskList.tsx
@@ -5,7 +5,7 @@ import { useUIStore } from "@/store/uiStore";
 import { useAuthStore } from "@/store/authStore";
 import { useWorkspaceStore } from "@/store/workspaceStore";
 import { TaskItem } from "./TaskItem";
-import type { Task } from "@/store/tasksStore";
+import type { Task, HabitGroup } from "@/store/tasksStore";
 import type { Priority, SortField, View } from "@/store/types";
 import { getISOWeekString } from "@/store/tasksStore";
 
@@ -204,13 +204,153 @@ function WeekDayGroup({ dateStr, tasks }: { dateStr: string; tasks: Task[] }) {
   );
 }
 
+// ── HabitGroupItem: one card per habit series in the Habits view ────────────
+const REPEAT_LABELS: Record<string, string> = {
+  daily: 'Daily',
+  weekly: 'Weekly',
+  monthly: 'Monthly',
+};
+
+function HabitGroupItem({ group }: { group: HabitGroup }) {
+  const [open, setOpen] = useState(true);
+  const [confirmDeleteAll, setConfirmDeleteAll] = useState(false);
+  const { deleteHabitInstances, tasks } = useTasksStore();
+  const { showNotification, openHabitSeriesModal } = useUIStore();
+  const { user } = useAuthStore();
+  const pct = Math.round(group.completionRate * 100);
+
+  const handleDeleteAll = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!confirmDeleteAll) { setConfirmDeleteAll(true); return; }
+    const rootTask = group.instances.find(t => !t.templateId) ?? group.instances[0];
+    if (!rootTask) return;
+    await deleteHabitInstances(group.habitId, 'all', rootTask.id, undefined, user?.id);
+    showNotification('Entire habit deleted', 'warning');
+    setConfirmDeleteAll(false);
+  };
+
+  return (
+    <div className="flex flex-col rounded-xl border border-emerald-500/20 bg-card">
+      {/* Header row */}
+      <div className="flex items-start gap-3 p-4 w-full">
+        <button
+          onClick={() => setOpen(o => !o)}
+          className="flex items-start gap-3 flex-1 min-w-0 text-left hover:opacity-80 transition-opacity"
+        >
+          <span className="text-lg mt-0.5 flex-shrink-0">🔁</span>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-sm font-semibold text-foreground leading-snug">{group.title}</span>
+              <span className="text-[11px] px-1.5 py-0.5 rounded-full bg-emerald-900/60 text-emerald-300 border border-emerald-700/40 font-medium">
+                {REPEAT_LABELS[group.repeat] ?? group.repeat}
+              </span>
+              {group.overdueCount > 0 && (
+                <span className="text-[11px] px-1.5 py-0.5 rounded-full bg-red-900/60 text-red-300 border border-red-700/40 font-medium">
+                  {group.overdueCount} overdue
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-3 mt-2">
+              <div className="flex-1 h-1.5 rounded-full bg-muted overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-emerald-500 transition-all duration-300"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+              <span className="text-xs text-muted-foreground flex-shrink-0">
+                {group.completedCount}/{group.totalCount} · {pct}%
+              </span>
+            </div>
+            <p className="text-xs text-muted-foreground mt-1">
+              From {group.startDate}
+              {group.repeatEndDate ? ` · Until ${group.repeatEndDate}` : ' · No end date'}
+            </p>
+          </div>
+        </button>
+        {/* Group actions */}
+        <div className="flex items-center gap-1 flex-shrink-0 mt-0.5">
+          {/* Edit series */}
+          {!confirmDeleteAll && (() => {
+            const rootTask = group.instances.find(t => !t.templateId) ?? group.instances[0];
+            return rootTask ? (
+              <button
+                onClick={(e) => { e.stopPropagation(); openHabitSeriesModal(rootTask); }}
+                title="Edit habit series"
+                className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                </svg>
+              </button>
+            ) : null;
+          })()}
+          {confirmDeleteAll ? (
+            <>
+              <button
+                onClick={handleDeleteAll}
+                className="text-xs px-2 py-1 rounded-lg bg-red-600 text-white hover:bg-red-700 transition-colors font-medium"
+              >
+                Confirm
+              </button>
+              <button
+                onClick={(e) => { e.stopPropagation(); setConfirmDeleteAll(false); }}
+                className="text-xs px-2 py-1 rounded-lg bg-muted text-muted-foreground hover:bg-accent transition-colors"
+              >
+                Cancel
+              </button>
+            </>
+          ) : (
+            <button
+              onClick={handleDeleteAll}
+              title="Delete entire habit series"
+              className="p-1.5 rounded-lg hover:bg-red-900/30 text-muted-foreground hover:text-red-400 transition-colors"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+            </button>
+          )}
+          <button
+            onClick={() => setOpen(o => !o)}
+            className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground transition-colors"
+            title={open ? 'Collapse' : 'Expand'}
+          >
+            <svg
+              className={`w-4 h-4 transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+              fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      {/* Expanded instances */}
+      {open && (
+        <div className="border-t border-border/40 px-4 py-3 flex flex-col gap-2">
+          {group.instances.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-2">No occurrences yet</p>
+          ) : (
+            group.instances.map(task => (
+              <TaskItem key={task.id} task={task} />
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export const TaskList = () => {
+  // habit filter: 'tasks' | 'habits' — used in views where both can coexist (Today, This Week, etc.)
+  const [habitFilter, setHabitFilter] = useState<'tasks' | 'habits' | null>(null);
+
   const {
     tasks: storeTasks,
     bulkComplete,
     bulkUndo,
     bulkDelete,
     bulkSetPriority,
+    getHabitGroups,
   } = useTasksStore();
 
   const {
@@ -225,6 +365,7 @@ export const TaskList = () => {
     toggleSortDir,
     showNotification,
     openTaskModal,
+    openHabitModal,
     activeWorkspaceId,
     setView,
   } = useUIStore();
@@ -258,16 +399,23 @@ export const TaskList = () => {
     const todayDate = new Date();
     todayDate.setHours(0, 0, 0, 0);
 
+    // Apply habitFilter on top of an already-filtered set (not used in All Tasks)
+    const applyHabitFilter = (base: Task[]) => {
+      if (habitFilter === 'tasks') return base.filter(t => !t.isHabit);
+      if (habitFilter === 'habits') return base.filter(t => t.isHabit);
+      return base;
+    };
+
     switch (currentView) {
       case "today":
-        return workspaceTasks.filter(
+        return applyHabitFilter(workspaceTasks.filter(
           (t) =>
             (t.status === "active" || t.status === "inProgress") &&
             !t.isTemplate &&
             t.dueDate === today,
-        );
+        ));
       case "completed":
-        return workspaceTasks.filter((t) => t.status === "completed");
+        return workspaceTasks.filter((t) => t.status === "completed" && !t.isHabit);
       case "thisWeek": {
         // Mon-Sun of current ISO week
         const now = new Date();
@@ -278,36 +426,44 @@ export const TaskList = () => {
         sun.setDate(mon.getDate() + 6);
         const monStr = `${mon.getFullYear()}-${String(mon.getMonth() + 1).padStart(2, '0')}-${String(mon.getDate()).padStart(2, '0')}`;
         const sunStr = `${sun.getFullYear()}-${String(sun.getMonth() + 1).padStart(2, '0')}-${String(sun.getDate()).padStart(2, '0')}`;
-        return workspaceTasks
+        return applyHabitFilter(workspaceTasks
           .filter((t) => {
             if ((t.status !== 'active' && t.status !== 'overdue') || t.isTemplate) return false;
             return !!t.dueDate && t.dueDate >= monStr && t.dueDate <= sunStr;
           })
-          .sort((a, b) => (a.dueDate ?? '').localeCompare(b.dueDate ?? ''));
+          .sort((a, b) => (a.dueDate ?? '').localeCompare(b.dueDate ?? '')));
       }
       case "overdue":
-        return workspaceTasks.filter(
+        return applyHabitFilter(workspaceTasks.filter(
           (t) => t.status === "overdue" && !t.isTemplate,
-        );
+        ));
+      case "habits":
+        // Habits view uses habitGroups separately; return empty so task count shows 0
+        return [];
       case "category":
-        if (!currentCategory) return workspaceTasks.filter((t) => (t.status === "active" || t.status === "inProgress" || t.status === "overdue") && !t.isTemplate);
+        if (!currentCategory) return applyHabitFilter(workspaceTasks.filter((t) => (t.status === "active" || t.status === "inProgress" || t.status === "overdue") && !t.isTemplate));
         if (currentCategory.startsWith("#")) {
-          // Tag view: filter by tags array
           const tagName = currentCategory.slice(1);
-          return workspaceTasks.filter(
+          return applyHabitFilter(workspaceTasks.filter(
             (t) =>
               (t.status === "active" || t.status === "inProgress" || t.status === "overdue") &&
               !t.isTemplate &&
               (t.tags ?? []).some((tag) => tag.trim() === tagName),
-          );
+          ));
         }
-        return workspaceTasks.filter(
+        return applyHabitFilter(workspaceTasks.filter(
           (t) => (t.status === "active" || t.status === "inProgress" || t.status === "overdue") && !t.isTemplate && t.category === currentCategory,
-        );
+        ));
       default:
-        return workspaceTasks.filter((t) => (t.status === "active" || t.status === "inProgress" || t.status === "overdue") && !t.isTemplate);
+        // All Tasks: always show only tasks — habits live in the dedicated Habits view
+        return workspaceTasks.filter((t) => (t.status === "active" || t.status === "inProgress" || t.status === "overdue") && !t.isTemplate && !t.isHabit);
     }
-  }, [workspaceTasks, currentView, currentCategory]);
+  }, [workspaceTasks, currentView, currentCategory, habitFilter]);
+
+  // Habits view: one entry per series (always computed so it's ready on view switch)
+  const habitGroups = useMemo(() => {
+    return getHabitGroups();
+  }, [storeTasks, getHabitGroups]);
 
   const tasks = useMemo(() => sortTasks(rawTasks, sortField, sortDir), [rawTasks, sortField, sortDir]);
 
@@ -427,6 +583,7 @@ export const TaskList = () => {
       return `This Week — W${weekNum} · ${rangeLabel}`;
     }
     if (currentView === "overdue") return "Overdue";
+    if (currentView === "habits") return "Habits";
     return currentView.charAt(0).toUpperCase() + currentView.slice(1);
   }, [currentView, currentCategory]);
 
@@ -437,8 +594,14 @@ export const TaskList = () => {
       <div className="flex items-center justify-between gap-2 flex-wrap">
         <div className="flex items-center gap-3">
           <h2 className="text-lg font-bold text-foreground">{viewLabel}</h2>
-          {tasks.length > 0 && (
-            <span className="text-sm text-muted-foreground">({tasks.length})</span>
+          {currentView === "habits" ? (
+            habitGroups.length > 0 && (
+              <span className="text-sm text-muted-foreground">({habitGroups.length})</span>
+            )
+          ) : (
+            tasks.length > 0 && (
+              <span className="text-sm text-muted-foreground">({tasks.length})</span>
+            )
           )}
         </div>
 
@@ -472,6 +635,27 @@ export const TaskList = () => {
           </button>
         </div>
       </div>
+
+      {/* Habit/Task filter chips — shown in views where habits can coexist with tasks (NOT in All Tasks) */}
+      {currentView !== "all" && currentView !== "habits" && currentView !== "completed" && (
+        <div className="flex items-center gap-1.5">
+          {([null, 'tasks', 'habits'] as const).map((f) => (
+            <button
+              key={f ?? 'all'}
+              onClick={() => setHabitFilter(f)}
+              className={`text-xs px-2.5 py-1 rounded-full font-medium transition-colors border ${
+                habitFilter === f
+                  ? f === 'habits'
+                    ? 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 border-emerald-500/30'
+                    : 'bg-primary/10 text-primary border-primary/30'
+                  : 'bg-transparent text-muted-foreground border-border hover:bg-accent'
+              }`}
+            >
+              {f === null ? 'All' : f === 'tasks' ? 'Tasks' : '🔁 Habits'}
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* Overdue info bar — shown in Today and This Week */}
       {(currentView === "today" || currentView === "thisWeek") && overdueCount > 0 && !overdueBannerDismissed && (
@@ -590,7 +774,25 @@ export const TaskList = () => {
       )}
 
       {/* Task list */}
-      {tasks.length === 0 ? (
+      {currentView === "habits" ? (
+        // ── Habits: one card per series ────────────────────────────────────────
+        <div className="flex flex-col gap-3">
+          {habitGroups.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-20 text-center">
+              <span className="text-4xl mb-3">🔁</span>
+              <p className="text-muted-foreground font-medium">No habits yet</p>
+              <button
+                onClick={() => openHabitModal()}
+                className="mt-3 text-sm text-primary hover:underline hover:cursor-pointer"
+              >
+                + Add your first habit
+              </button>
+            </div>
+          ) : (
+            habitGroups.map(g => <HabitGroupItem key={g.habitId} group={g} />)
+          )}
+        </div>
+      ) : tasks.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-20 text-center">
           <svg className="w-12 h-12 text-muted-foreground/30 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />

--- a/src/app/components/tasks/displayTasks/templateSheet.tsx
+++ b/src/app/components/tasks/displayTasks/templateSheet.tsx
@@ -48,8 +48,6 @@ const EMPTY_FORM: TaskFormState = {
   title: "",
   description: "",
   dueDate: "",
-  startDate: "",
-  repeatEndDate: "",
   priority: "medium",
   workspace: "",
   category: "",

--- a/src/app/components/tasks/displayTasks/templateSheet.tsx
+++ b/src/app/components/tasks/displayTasks/templateSheet.tsx
@@ -48,6 +48,8 @@ const EMPTY_FORM: TaskFormState = {
   title: "",
   description: "",
   dueDate: "",
+  startDate: "",
+  repeatEndDate: "",
   priority: "medium",
   workspace: "",
   category: "",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -81,6 +81,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
               <Route path="/calendar" element={<App />} />
               <Route path="/completed" element={<App />} />
               <Route path="/overdue" element={<App />} />
+              <Route path="/habits" element={<App />} />
               <Route path="/planner" element={<App />} />
               <Route path="/planner-week" element={<App />} />
               <Route path="/auth/callback" element={<AuthCallback />} />

--- a/src/store/tasksStore.ts
+++ b/src/store/tasksStore.ts
@@ -21,10 +21,6 @@ export interface Task {
   priority?: Priority;
   category?: string;
   repeat?: Repeat;
-  // ── Repeat-only fields ──
-  startDate?: string;     // YYYY-MM-DD — first occurrence / cycle start
-  repeatEndDate?: string; // YYYY-MM-DD — last occurrence / end of cycle (undefined = infinite)
-  templateId?: string;    // UUID — for instances: ID of the template task that generated this
   tags?: string[];
   notes?: string;
   subtasks?: Subtask[];
@@ -334,8 +330,6 @@ export const useTasksStore = create<TasksState>((set, get) => ({
       category: form.category,
       workspace: form.workspace || undefined,
       repeat: form.repeat,
-      startDate: form.repeat !== 'none' ? (form.startDate || undefined) : undefined,
-      repeatEndDate: form.repeat !== 'none' ? (form.repeatEndDate || undefined) : undefined,
       tags: tags.length > 0 ? tags : undefined,
       notes: form.notes || undefined,
       subtasks: form.subtasks.length > 0 ? form.subtasks : undefined,
@@ -371,8 +365,6 @@ export const useTasksStore = create<TasksState>((set, get) => ({
           category: newTask.category ?? null,
           workspace: newTask.workspace ?? null,
           repeat: newTask.repeat ?? null,
-          start_date: newTask.startDate ?? null,
-          repeat_end_date: newTask.repeatEndDate ?? null,
           tags: newTask.tags ?? null,
           notes: newTask.notes ?? null,
           subtasks: newTask.subtasks ? JSON.stringify(newTask.subtasks) : '[]',
@@ -440,8 +432,6 @@ export const useTasksStore = create<TasksState>((set, get) => ({
       if (resolvedUpdates.category     !== undefined) supabaseUpdates.category    = resolvedUpdates.category ?? null;
       if (resolvedUpdates.workspace    !== undefined) supabaseUpdates.workspace   = resolvedUpdates.workspace ?? null;
       if (resolvedUpdates.repeat       !== undefined) supabaseUpdates.repeat      = resolvedUpdates.repeat ?? null;
-      if ('startDate' in resolvedUpdates)     supabaseUpdates.start_date      = resolvedUpdates.startDate ?? null;
-      if ('repeatEndDate' in resolvedUpdates) supabaseUpdates.repeat_end_date = resolvedUpdates.repeatEndDate ?? null;
       if (resolvedUpdates.tags         !== undefined) supabaseUpdates.tags        = resolvedUpdates.tags ?? null;
       if (resolvedUpdates.notes        !== undefined) supabaseUpdates.notes       = resolvedUpdates.notes ?? null;
       if (resolvedUpdates.subtasks     !== undefined) supabaseUpdates.subtasks    = JSON.stringify(resolvedUpdates.subtasks ?? []);
@@ -843,9 +833,6 @@ export const useTasksStore = create<TasksState>((set, get) => ({
         category: t.category ?? undefined,
         workspace: t.workspace ?? undefined,
         repeat: t.repeat ?? undefined,
-        startDate: t.start_date ?? undefined,
-        repeatEndDate: t.repeat_end_date ?? undefined,
-        templateId: t.template_id ?? undefined,
         tags: t.tags ?? undefined,
         notes: t.notes ?? undefined,
         subtasks: t.subtasks ? (typeof t.subtasks === 'string' ? JSON.parse(t.subtasks) : t.subtasks) : undefined,

--- a/src/store/tasksStore.ts
+++ b/src/store/tasksStore.ts
@@ -21,6 +21,10 @@ export interface Task {
   priority?: Priority;
   category?: string;
   repeat?: Repeat;
+  // ── Repeat-only fields ──
+  startDate?: string;     // YYYY-MM-DD — first occurrence / cycle start
+  repeatEndDate?: string; // YYYY-MM-DD — last occurrence / end of cycle (undefined = infinite)
+  templateId?: string;    // UUID — for instances: ID of the template task that generated this
   tags?: string[];
   notes?: string;
   subtasks?: Subtask[];
@@ -330,6 +334,8 @@ export const useTasksStore = create<TasksState>((set, get) => ({
       category: form.category,
       workspace: form.workspace || undefined,
       repeat: form.repeat,
+      startDate: form.repeat !== 'none' ? (form.startDate || undefined) : undefined,
+      repeatEndDate: form.repeat !== 'none' ? (form.repeatEndDate || undefined) : undefined,
       tags: tags.length > 0 ? tags : undefined,
       notes: form.notes || undefined,
       subtasks: form.subtasks.length > 0 ? form.subtasks : undefined,
@@ -365,6 +371,8 @@ export const useTasksStore = create<TasksState>((set, get) => ({
           category: newTask.category ?? null,
           workspace: newTask.workspace ?? null,
           repeat: newTask.repeat ?? null,
+          start_date: newTask.startDate ?? null,
+          repeat_end_date: newTask.repeatEndDate ?? null,
           tags: newTask.tags ?? null,
           notes: newTask.notes ?? null,
           subtasks: newTask.subtasks ? JSON.stringify(newTask.subtasks) : '[]',
@@ -432,6 +440,8 @@ export const useTasksStore = create<TasksState>((set, get) => ({
       if (resolvedUpdates.category     !== undefined) supabaseUpdates.category    = resolvedUpdates.category ?? null;
       if (resolvedUpdates.workspace    !== undefined) supabaseUpdates.workspace   = resolvedUpdates.workspace ?? null;
       if (resolvedUpdates.repeat       !== undefined) supabaseUpdates.repeat      = resolvedUpdates.repeat ?? null;
+      if ('startDate' in resolvedUpdates)     supabaseUpdates.start_date      = resolvedUpdates.startDate ?? null;
+      if ('repeatEndDate' in resolvedUpdates) supabaseUpdates.repeat_end_date = resolvedUpdates.repeatEndDate ?? null;
       if (resolvedUpdates.tags         !== undefined) supabaseUpdates.tags        = resolvedUpdates.tags ?? null;
       if (resolvedUpdates.notes        !== undefined) supabaseUpdates.notes       = resolvedUpdates.notes ?? null;
       if (resolvedUpdates.subtasks     !== undefined) supabaseUpdates.subtasks    = JSON.stringify(resolvedUpdates.subtasks ?? []);
@@ -833,6 +843,9 @@ export const useTasksStore = create<TasksState>((set, get) => ({
         category: t.category ?? undefined,
         workspace: t.workspace ?? undefined,
         repeat: t.repeat ?? undefined,
+        startDate: t.start_date ?? undefined,
+        repeatEndDate: t.repeat_end_date ?? undefined,
+        templateId: t.template_id ?? undefined,
         tags: t.tags ?? undefined,
         notes: t.notes ?? undefined,
         subtasks: t.subtasks ? (typeof t.subtasks === 'string' ? JSON.parse(t.subtasks) : t.subtasks) : undefined,

--- a/src/store/tasksStore.ts
+++ b/src/store/tasksStore.ts
@@ -15,9 +15,12 @@ export interface Task {
   isTemplate?: boolean;
   userId?: string;
   // ── Rich task fields (merged from taskflow-react) ──
-  title?: string;        // display title (falls back to text if not set)
+  title?: string;         // display title (falls back to text if not set)
   description?: string;
-  dueDate?: string;      // YYYY-MM-DD
+  dueDate?: string;       // YYYY-MM-DD — per-instance due date
+  startDate?: string;     // YYYY-MM-DD — first occurrence / cycle start (repeat tasks only)
+  repeatEndDate?: string; // YYYY-MM-DD — last occurrence / end of cycle (undefined = infinite)
+  templateId?: string;    // UUID — for instances: ID of the template task that generated them
   priority?: Priority;
   category?: string;
   repeat?: Repeat;
@@ -25,6 +28,7 @@ export interface Task {
   notes?: string;
   subtasks?: Subtask[];
   workspace?: string;
+  isHabit?: boolean;   // true for every instance of a repeating (habit) series
   saveError?: boolean;
 }
 
@@ -63,6 +67,7 @@ interface TasksState {
   getUpcomingTasks: () => Task[];
   getTasksByCategory: (category: string) => Task[];
   searchTasks: (query: string) => Task[];
+  getHabitGroups: () => HabitGroup[];
 
   // Actions
   addTask: (text: string, userId?: string) => Promise<void>;
@@ -70,6 +75,8 @@ interface TasksState {
   updateTask: (id: string, text: string, userId?: string) => Promise<void>;
   updateTaskRich: (id: string, updates: Partial<Task>, userId?: string) => Promise<void>;
   deleteTask: (id: string, userId?: string) => Promise<void>;
+  deleteHabitInstances: (habitId: string, mode: 'this' | 'future' | 'all', taskId: string, fromDate?: string, userId?: string) => Promise<void>;
+  ensureHabitInstances: (userId?: string) => Promise<void>;
   markAsCompleted: (id: string, userId?: string) => Promise<void>;
   undoTask: (id: string, userId?: string) => Promise<void>;
   archiveTask: (id: string, userId?: string) => Promise<void>;
@@ -93,6 +100,83 @@ interface TasksState {
 }
 
 const STORAGE_KEY = 'doitly_tasks_v2';
+
+// ── HabitGroup: aggregated view of a repeating series ───────────────────────
+export interface HabitGroup {
+  habitId: string;          // = templateId of root task (or id of root itself)
+  title: string;
+  repeat: Repeat;
+  startDate: string;
+  repeatEndDate?: string;
+  totalCount: number;
+  completedCount: number;
+  overdueCount: number;
+  completionRate: number;   // 0–1 fraction
+  instances: Task[];
+}
+
+// ── Repeat instance generator ────────────────────────────────────────────────
+// Generates occurrence dates within a window:
+//   - Start: max(startDate, today)
+//   - End: min(repeatEndDate, today + 30 days)
+// This "lazy 30-day" approach avoids creating hundreds of instances upfront.
+// More instances are generated automatically when loadTasks() detects coverage
+// is running low (see ensureHabitInstances).
+
+/** Generates dates in [windowStart, windowEnd] following the repeat rule. */
+function generateRepeatDates(
+  startDate: string,
+  repeat: 'daily' | 'weekly' | 'monthly',
+  repeatEndDate?: string,
+  windowStart?: string,   // default = startDate
+  windowEnd?: string,     // default = today+30 days
+): string[] {
+  const dates: string[] = [];
+
+  // Determine the generation window
+  const todayDate = new Date();
+  todayDate.setHours(0, 0, 0, 0);
+  const plus30 = new Date(todayDate);
+  plus30.setDate(todayDate.getDate() + 30);
+
+  // Series hard end
+  const seriesEnd = repeatEndDate ? (() => {
+    const [ey, em, ed] = repeatEndDate.split('-').map(Number);
+    return new Date(ey, em - 1, ed);
+  })() : null;
+
+  // Effective window end = min(seriesEnd, today+30)
+  const effectiveEnd = seriesEnd ? (seriesEnd < plus30 ? seriesEnd : plus30) : plus30;
+
+  // Window start supplied (used when expanding forward) — else use startDate
+  const winStartStr = windowStart ?? startDate;
+  const [wsy, wsm, wsd] = winStartStr.split('-').map(Number);
+  const winStartDate = new Date(wsy, wsm - 1, wsd);
+
+  // Iterate from startDate until we're within window
+  const [sy, sm, sd] = startDate.split('-').map(Number);
+  const current = new Date(sy, sm - 1, sd);
+
+  while (current <= effectiveEnd) {
+    if (current >= winStartDate) {
+      const yyyy = current.getFullYear();
+      const mm   = String(current.getMonth() + 1).padStart(2, '0');
+      const dd   = String(current.getDate()).padStart(2, '0');
+      dates.push(`${yyyy}-${mm}-${dd}`);
+    }
+
+    // Advance
+    if (repeat === 'daily') {
+      current.setDate(current.getDate() + 1);
+    } else if (repeat === 'weekly') {
+      current.setDate(current.getDate() + 7);
+    } else if (repeat === 'monthly') {
+      current.setMonth(current.getMonth() + 1);
+    }
+  }
+
+  return dates;
+}
 
 const getLocalTasks = (): Task[] => {
   if (typeof window === 'undefined') return [];
@@ -217,7 +301,7 @@ export const useTasksStore = create<TasksState>((set, get) => ({
   // Getters
   getActiveTasks: () => get().tasks.filter(t => (t.status === 'active' || t.status === 'inProgress' || t.status === 'overdue') && !t.isTemplate),
   getCompletedTasks: () => get().tasks.filter(t => t.status === 'completed'),
-  getDeletedTasks: () => get().tasks.filter(t => t.status === 'deleted').slice(-10), // Last 10
+  getDeletedTasks: () => get().tasks.filter(t => t.status === 'deleted' && !t.isHabit).slice(-10), // Last 10, habits excluded
   getArchivedTasks: () => get().tasks.filter(t => t.status === 'archived'),
   getTemplates: () => get().tasks.filter(t => t.isTemplate),
   getStats: () => calculateStats(get().tasks),
@@ -313,74 +397,143 @@ export const useTasksStore = create<TasksState>((set, get) => ({
     }
   },
 
-  // ── addTaskRich: create a task with all rich fields ──
+  // ── addTaskRich: create a task (or a series of repeat instances) ──
   addTaskRich: async (form: TaskFormState, userId?: string) => {
     const tags = form.tags
       .split(',')
       .map(t => t.trim())
       .filter(Boolean);
 
-    const newTask: Task = {
-      id: crypto.randomUUID(),
-      text: form.title,
-      title: form.title,
-      description: form.description || undefined,
-      dueDate: form.dueDate || undefined,
-      priority: form.priority,
-      category: form.category,
-      workspace: form.workspace || undefined,
-      repeat: form.repeat,
-      tags: tags.length > 0 ? tags : undefined,
-      notes: form.notes || undefined,
-      subtasks: form.subtasks.length > 0 ? form.subtasks : undefined,
-      status: 'active',
-      createdAt: new Date().toISOString(),
-      userId,
-    };
+    const isRepeat = form.repeat !== 'none';
+    const now = new Date().toISOString();
 
-    // Optimistic update: add task to store immediately for instant UI feedback
-    const optimisticTasks = [...get().tasks, newTask];
+    // ── Build task(s) to insert ───────────────────────────────────────────────
+    let newTasks: Task[];
+
+    if (isRepeat && form.startDate) {
+      // Generate one task per occurrence in the repeat series.
+      // Each instance shares all fields but gets its own id + dueDate.
+      const dates = generateRepeatDates(
+        form.startDate,
+        form.repeat as 'daily' | 'weekly' | 'monthly',
+        form.repeatEndDate || undefined,
+      );
+
+      // Root is the first instance. Its id is used as templateId for all others.
+      // NOTE: templateId is deliberately NOT set on the root itself so it can be
+      // inserted without a FK cycle (root row must exist before instances reference it).
+      const rootId = crypto.randomUUID();
+
+      newTasks = dates.map((date, idx) => ({
+        id: idx === 0 ? rootId : crypto.randomUUID(),
+        text: form.title,
+        title: form.title,
+        description: form.description || undefined,
+        dueDate: date,
+        startDate: form.startDate,
+        repeatEndDate: form.repeatEndDate || undefined,
+        // Root has no templateId; instances reference the root
+        templateId: idx === 0 ? undefined : rootId,
+        priority: form.priority,
+        category: form.category || undefined,
+        workspace: form.workspace || undefined,
+        repeat: form.repeat,
+        tags: tags.length > 0 ? tags : undefined,
+        notes: form.notes || undefined,
+        subtasks: form.subtasks.length > 0 ? form.subtasks : undefined,
+        status: 'active' as const,
+        isHabit: true,
+        createdAt: now,
+        userId,
+      }));
+    } else {
+      // Single task (no repeat)
+      newTasks = [{
+        id: crypto.randomUUID(),
+        text: form.title,
+        title: form.title,
+        description: form.description || undefined,
+        dueDate: form.dueDate || undefined,
+        priority: form.priority,
+        category: form.category || undefined,
+        workspace: form.workspace || undefined,
+        repeat: form.repeat,
+        tags: tags.length > 0 ? tags : undefined,
+        notes: form.notes || undefined,
+        subtasks: form.subtasks.length > 0 ? form.subtasks : undefined,
+        status: 'active' as const,
+        createdAt: now,
+        userId,
+      }];
+    }
+
+    // Optimistic update — add all instances to store immediately
+    const optimisticTasks = [...get().tasks, ...newTasks];
     set({ tasks: optimisticTasks });
     if (!userId) saveLocalTasks(optimisticTasks);
 
     if (userId) {
-      // Rate limit: max 60 tasks/hour per user
-      const { data: allowed } = await supabase.rpc('check_task_rate_limit');
-      if (!allowed) {
-        console.warn('[tasksStore] Rate limit exceeded');
-        // Rollback optimistic update
-        set({ tasks: get().tasks.filter(t => t.id !== newTask.id) });
-        return;
+      const toRow = (task: Task) => ({
+        id: task.id,
+        text: task.text,
+        title: task.title ?? null,
+        description: task.description ?? null,
+        due_date: task.dueDate ?? null,
+        start_date: task.startDate ?? null,
+        repeat_end_date: task.repeatEndDate ?? null,
+        template_id: task.templateId ?? null,
+        priority: task.priority ?? null,
+        category: task.category ?? null,
+        workspace: task.workspace ?? null,
+        repeat: task.repeat ?? null,
+        tags: task.tags ?? null,
+        notes: task.notes ?? null,
+        subtasks: task.subtasks ? JSON.stringify(task.subtasks) : '[]',
+        status: task.status,
+        is_habit: task.isHabit ?? false,
+        is_template: false,
+        user_id: userId,
+        created_at: task.createdAt,
+      });
+
+      // For repeat series: insert root first (so FK template_id → tasks(id) is satisfied),
+      // then all instances in a single batch. For a single task: one insert.
+      const insertedIds = new Set(newTasks.map(t => t.id));
+
+      const markFailed = () => {
+        set({ tasks: get().tasks.map(t => insertedIds.has(t.id) ? { ...t, saveError: true } : t) });
+      };
+
+      if (newTasks.length === 1) {
+        const { error } = await supabase.from('tasks').insert([toRow(newTasks[0])]);
+        if (error) {
+          console.error('Error adding task to Supabase:', error);
+          markFailed();
+          throw error;
+        }
+      } else {
+        // Step 1: insert root (index 0)
+        const { error: rootError } = await supabase.from('tasks').insert([toRow(newTasks[0])]);
+        if (rootError) {
+          console.error('Error inserting root repeat task:', rootError);
+          markFailed();
+          throw rootError;
+        }
+        // Step 2: insert all instances in one batch (they can now reference rootId via FK)
+        // Chunk into batches of 50 to stay safely within Supabase request size limits
+        const instances = newTasks.slice(1);
+        const CHUNK = 50;
+        for (let i = 0; i < instances.length; i += CHUNK) {
+          const chunk = instances.slice(i, i + CHUNK).map(toRow);
+          const { error: chunkError } = await supabase.from('tasks').insert(chunk);
+          if (chunkError) {
+            console.error(`Error inserting repeat instances (chunk ${i / CHUNK + 1}):`, chunkError);
+            markFailed();
+            throw chunkError;
+          }
+        }
       }
 
-      const { error } = await supabase
-        .from('tasks')
-        .insert([{
-          id: newTask.id,
-          text: newTask.text,
-          title: newTask.title,
-          description: newTask.description ?? null,
-          due_date: newTask.dueDate ?? null,
-          priority: newTask.priority ?? null,
-          category: newTask.category ?? null,
-          workspace: newTask.workspace ?? null,
-          repeat: newTask.repeat ?? null,
-          tags: newTask.tags ?? null,
-          notes: newTask.notes ?? null,
-          subtasks: newTask.subtasks ? JSON.stringify(newTask.subtasks) : '[]',
-          status: newTask.status,
-          is_template: false,
-          user_id: userId,
-          created_at: newTask.createdAt,
-        }]);
-
-      if (error) {
-        console.error('Error adding rich task to Supabase:', error);
-        // Mark task as failed (keep it visible with error indicator, allow retry)
-        set({ tasks: get().tasks.map(t => t.id === newTask.id ? { ...t, saveError: true } : t) });
-        throw error;
-      }
-      // Sync with Supabase in background (don't block UI)
       get().loadTasks(userId);
     }
   },
@@ -427,7 +580,9 @@ export const useTasksStore = create<TasksState>((set, get) => ({
       }
       if (resolvedUpdates.description !== undefined) supabaseUpdates.description = resolvedUpdates.description ?? null;
       // Use 'in' not '!== undefined' so explicit dueDate removal (undefined) also writes null to DB
-      if ('dueDate' in resolvedUpdates) supabaseUpdates.due_date = resolvedUpdates.dueDate ?? null;
+      if ('dueDate' in resolvedUpdates)       supabaseUpdates.due_date        = resolvedUpdates.dueDate ?? null;
+      if ('startDate' in resolvedUpdates)     supabaseUpdates.start_date      = resolvedUpdates.startDate ?? null;
+      if ('repeatEndDate' in resolvedUpdates) supabaseUpdates.repeat_end_date = resolvedUpdates.repeatEndDate ?? null;
       if (resolvedUpdates.priority     !== undefined) supabaseUpdates.priority    = resolvedUpdates.priority ?? null;
       if (resolvedUpdates.category     !== undefined) supabaseUpdates.category    = resolvedUpdates.category ?? null;
       if (resolvedUpdates.workspace    !== undefined) supabaseUpdates.workspace   = resolvedUpdates.workspace ?? null;
@@ -829,6 +984,9 @@ export const useTasksStore = create<TasksState>((set, get) => ({
         title: t.title ?? undefined,
         description: t.description ?? undefined,
         dueDate: t.due_date ?? undefined,
+        startDate: t.start_date ?? undefined,
+        repeatEndDate: t.repeat_end_date ?? undefined,
+        templateId: t.template_id ?? undefined,
         priority: t.priority ?? undefined,
         category: t.category ?? undefined,
         workspace: t.workspace ?? undefined,
@@ -847,10 +1005,13 @@ export const useTasksStore = create<TasksState>((set, get) => ({
         deletedAt: t.deleted_at || undefined,
         archivedAt: t.archived_at || undefined,
         isTemplate: t.is_template || false,
+        isHabit: t.is_habit || false,
         userId: t.user_id,
       })) || [];
 
       set({ tasks, loading: false });
+      // After loading, ensure habits have enough future instances
+      await get().ensureHabitInstances(userId);
     } else {
 
       const tasks = getLocalTasks();
@@ -894,6 +1055,222 @@ export const useTasksStore = create<TasksState>((set, get) => ({
     }
   },
 
+  // ── getHabitGroups: aggregate habit instances into one entry per series ──
+  getHabitGroups: (): HabitGroup[] => {
+    const allTasks = get().tasks;
+    const habitTasks = allTasks.filter(t => t.isHabit && !t.isTemplate && t.status !== 'deleted' && t.status !== 'archived');
+
+    const grouped = new Map<string, Task[]>();
+    for (const t of habitTasks) {
+      const key = t.templateId ?? t.id;
+      if (!grouped.has(key)) grouped.set(key, []);
+      grouped.get(key)!.push(t);
+    }
+
+    const groups: HabitGroup[] = [];
+    for (const [habitId, instances] of grouped.entries()) {
+      const root = instances.find(t => !t.templateId) ?? instances[0];
+      const nonDeleted = instances.filter(t => t.status !== 'deleted' && t.status !== 'archived');
+      const completed = nonDeleted.filter(t => t.status === 'completed');
+      const overdue = nonDeleted.filter(t => t.status === 'overdue');
+      groups.push({
+        habitId,
+        title: root.title ?? root.text,
+        repeat: root.repeat ?? 'daily',
+        startDate: root.startDate ?? root.dueDate ?? root.createdAt.slice(0, 10),
+        repeatEndDate: root.repeatEndDate,
+        totalCount: nonDeleted.length,
+        completedCount: completed.length,
+        overdueCount: overdue.length,
+        completionRate: nonDeleted.length > 0 ? completed.length / nonDeleted.length : 0,
+        instances: nonDeleted.sort((a, b) => (a.dueDate ?? '').localeCompare(b.dueDate ?? '')),
+      });
+    }
+
+    return groups.sort((a, b) => a.startDate.localeCompare(b.startDate));
+  },
+
+  // ── deleteHabitInstances: delete one / future / all instances of a habit ──
+  deleteHabitInstances: async (
+    habitId: string,
+    mode: 'this' | 'future' | 'all',
+    taskId: string,
+    fromDate?: string,
+    userId?: string,
+  ) => {
+    const deletedAt = new Date().toISOString();
+    const allTasks = get().tasks;
+
+    let idsToDelete: string[];
+
+    if (mode === 'this') {
+      idsToDelete = [taskId];
+    } else if (mode === 'future') {
+      const cutoff = fromDate ?? '';
+      idsToDelete = allTasks
+        .filter(t => (t.templateId === habitId || t.id === habitId) && t.isHabit && (t.dueDate ?? '') >= cutoff)
+        .map(t => t.id);
+      if (!idsToDelete.includes(taskId)) idsToDelete.push(taskId);
+    } else {
+      idsToDelete = allTasks
+        .filter(t => t.templateId === habitId || t.id === habitId)
+        .map(t => t.id);
+    }
+
+    if (userId) {
+      const validIds = idsToDelete.filter(isValidUUID);
+      if (validIds.length > 0) {
+        const CHUNK = 50;
+        for (let i = 0; i < validIds.length; i += CHUNK) {
+          const chunk = validIds.slice(i, i + CHUNK);
+          await supabase
+            .from('tasks')
+            .update({ status: 'deleted', deleted_at: deletedAt })
+            .in('id', chunk)
+            .eq('user_id', userId);
+        }
+      }
+      await get().loadTasks(userId);
+    } else {
+      const idSet = new Set(idsToDelete);
+      const tasks = get().tasks.map(t =>
+        idSet.has(t.id) ? { ...t, status: 'deleted' as TaskStatus, deletedAt } : t,
+      );
+      set({ tasks });
+      saveLocalTasks(tasks);
+    }
+  },
+
+  // ── ensureHabitInstances: generate new instances for habits running low on coverage ──
+  ensureHabitInstances: async (userId?: string) => {
+    const allTasks = get().tasks;
+    const todayDate = new Date();
+    todayDate.setHours(0, 0, 0, 0);
+    const today = localDateStr(todayDate);
+    const threshold = new Date(todayDate);
+    threshold.setDate(todayDate.getDate() + 28);
+    const thresholdStr = localDateStr(threshold);
+
+    const roots = allTasks.filter(
+      t => t.isHabit && !t.templateId && !t.isTemplate &&
+           t.status !== 'deleted' && t.status !== 'archived',
+    );
+
+    const newInstances: Task[] = [];
+
+    for (const root of roots) {
+      if (!root.repeat || root.repeat === 'none') continue;
+      if (!root.startDate) continue;
+      if (root.repeatEndDate && root.repeatEndDate < today) continue;
+
+      const seriesInstances = allTasks.filter(
+        t => (t.templateId === root.id || t.id === root.id) &&
+             t.isHabit &&
+             (t.status === 'active' || t.status === 'overdue' || t.status === 'inProgress'),
+      );
+
+      const futureDates = seriesInstances
+        .map(t => t.dueDate ?? '')
+        .filter(d => d >= today)
+        .sort();
+
+      const lastCoveredDate = futureDates.length > 0 ? futureDates[futureDates.length - 1] : '';
+      if (lastCoveredDate >= thresholdStr) continue;
+
+      const existingDates = new Set(
+        allTasks
+          .filter(t => t.templateId === root.id || t.id === root.id)
+          .map(t => t.dueDate ?? ''),
+      );
+
+      const windowStart = lastCoveredDate
+        ? (() => {
+            const d = new Date(lastCoveredDate + 'T00:00:00');
+            d.setDate(d.getDate() + 1);
+            return localDateStr(d);
+          })()
+        : today;
+
+      const newDates = generateRepeatDates(
+        root.startDate,
+        root.repeat as 'daily' | 'weekly' | 'monthly',
+        root.repeatEndDate,
+        windowStart,
+      ).filter(d => !existingDates.has(d));
+
+      if (newDates.length === 0) continue;
+
+      const now = new Date().toISOString();
+      for (const date of newDates) {
+        newInstances.push({
+          id: crypto.randomUUID(),
+          text: root.text,
+          title: root.title,
+          description: root.description,
+          dueDate: date,
+          startDate: root.startDate,
+          repeatEndDate: root.repeatEndDate,
+          templateId: root.id,
+          priority: root.priority,
+          category: root.category,
+          workspace: root.workspace,
+          repeat: root.repeat,
+          tags: root.tags,
+          notes: root.notes,
+          subtasks: root.subtasks,
+          status: 'active' as const,
+          isHabit: true,
+          createdAt: now,
+          userId,
+        });
+      }
+    }
+
+    if (newInstances.length === 0) return;
+
+    const optimistic = [...get().tasks, ...newInstances];
+    set({ tasks: optimistic });
+
+    if (userId) {
+      const toRow = (t: Task) => ({
+        id: t.id,
+        text: t.text,
+        title: t.title ?? null,
+        description: t.description ?? null,
+        due_date: t.dueDate ?? null,
+        start_date: t.startDate ?? null,
+        repeat_end_date: t.repeatEndDate ?? null,
+        template_id: t.templateId ?? null,
+        priority: t.priority ?? null,
+        category: t.category ?? null,
+        workspace: t.workspace ?? null,
+        repeat: t.repeat ?? null,
+        tags: t.tags ?? null,
+        notes: t.notes ?? null,
+        subtasks: t.subtasks ? JSON.stringify(t.subtasks) : '[]',
+        status: t.status,
+        is_habit: true,
+        is_template: false,
+        user_id: userId,
+        created_at: t.createdAt,
+      });
+
+      const CHUNK = 50;
+      for (let i = 0; i < newInstances.length; i += CHUNK) {
+        const chunk = newInstances.slice(i, i + CHUNK).map(toRow);
+        const { error } = await supabase.from('tasks').insert(chunk);
+        if (error) {
+          console.error('[ensureHabitInstances] Insert error:', error);
+          const ids = new Set(newInstances.map(inst => inst.id));
+          set({ tasks: get().tasks.map(t => ids.has(t.id) ? { ...t, saveError: true } : t) });
+          return;
+        }
+      }
+    } else {
+      saveLocalTasks(get().tasks);
+    }
+  },
+
   // ── retryTask: attempt to re-save a failed task (saveError: true) to Supabase ──
   retryTask: async (id: string, userId?: string) => {
     const task = get().tasks.find(t => t.id === id);
@@ -907,6 +1284,9 @@ export const useTasksStore = create<TasksState>((set, get) => ({
         title: task.title ?? null,
         description: task.description ?? null,
         due_date: task.dueDate ?? null,
+        start_date: task.startDate ?? null,
+        repeat_end_date: task.repeatEndDate ?? null,
+        template_id: task.templateId ?? null,
         priority: task.priority ?? null,
         category: task.category ?? null,
         workspace: task.workspace ?? null,
@@ -915,6 +1295,7 @@ export const useTasksStore = create<TasksState>((set, get) => ({
         notes: task.notes ?? null,
         subtasks: task.subtasks ? JSON.stringify(task.subtasks) : '[]',
         status: task.status,
+        is_habit: task.isHabit ?? false,
         is_template: false,
         user_id: userId,
         created_at: task.createdAt,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -2,7 +2,7 @@
 
 export type Priority = 'low' | 'medium' | 'high';
 export type Repeat = 'none' | 'daily' | 'weekly' | 'monthly';
-export type View = 'all' | 'today' | 'completed' | 'category' | 'planDay' | 'planWeek' | 'planMonth' | 'thisWeek' | 'overdue';
+export type View = 'all' | 'today' | 'completed' | 'category' | 'planDay' | 'planWeek' | 'planMonth' | 'thisWeek' | 'overdue' | 'habits';
 export type SortField = 'created' | 'dueDate' | 'priority' | 'title';
 export type SortDir = 'asc' | 'desc';
 
@@ -30,7 +30,12 @@ export interface AppSettings {
 export type TaskFormState = {
   title: string;
   description: string;
+  /** Per-task due date — used when repeat === 'none' */
   dueDate: string;
+  /** First occurrence / cycle start — required when repeat !== 'none' */
+  startDate: string;
+  /** Last occurrence / cycle end — optional (empty = infinite) — only for repeat tasks */
+  repeatEndDate: string;
   priority: Priority;
   workspace: string;
   category: string;
@@ -42,6 +47,7 @@ export type TaskFormState = {
 
 export interface ModalState {
   task: boolean;
+  habit: boolean;
   search: boolean;
   focus: boolean;
   settings: boolean;

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -31,9 +31,6 @@ export type TaskFormState = {
   title: string;
   description: string;
   dueDate: string;
-  // ── Repeat fields (only relevant when repeat !== 'none') ──
-  startDate: string;       // first occurrence / cycle start (YYYY-MM-DD)
-  repeatEndDate: string;   // last occurrence / end of cycle (YYYY-MM-DD), empty = infinite
   priority: Priority;
   workspace: string;
   category: string;

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -31,6 +31,9 @@ export type TaskFormState = {
   title: string;
   description: string;
   dueDate: string;
+  // ── Repeat fields (only relevant when repeat !== 'none') ──
+  startDate: string;       // first occurrence / cycle start (YYYY-MM-DD)
+  repeatEndDate: string;   // last occurrence / end of cycle (YYYY-MM-DD), empty = infinite
   priority: Priority;
   workspace: string;
   category: string;

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -62,6 +62,8 @@ interface UIState {
   // Modal state
   modals: ModalState;
   editingTask: Task | null;
+  /** 'instance' = editing a single occurrence, 'series' = editing entire habit series, null = creating */
+  habitEditMode: 'instance' | 'series' | null;
 
   // Notifications
   notifications: AppNotification[];
@@ -85,6 +87,8 @@ interface UIState {
   setActiveWorkspaceId: (id: string) => void;
 
   openTaskModal: (task?: Task) => void;
+  openHabitModal: (task?: Task) => void;
+  openHabitSeriesModal: (task: Task) => void;
   openSearchModal: () => void;
   openFocusModal: () => void;
   openSettingsModal: () => void;
@@ -130,6 +134,7 @@ function saveSettings(settings: AppSettings) {
 
 const CLOSED_MODALS: ModalState = {
   task: false,
+  habit: false,
   search: false,
   focus: false,
   settings: false,
@@ -168,6 +173,7 @@ export const useUIStore = create<UIState>((set, get) => ({
 
   modals: { ...CLOSED_MODALS },
   editingTask: null,
+  habitEditMode: null,
 
   notifications: [],
 
@@ -203,6 +209,10 @@ export const useUIStore = create<UIState>((set, get) => ({
   // ── Modals ──
   openTaskModal: (task) =>
     set({ modals: { ...CLOSED_MODALS, task: true }, editingTask: task ?? null }),
+  openHabitModal: (task) =>
+    set({ modals: { ...CLOSED_MODALS, habit: true }, editingTask: task ?? null, habitEditMode: task ? 'instance' : null }),
+  openHabitSeriesModal: (task) =>
+    set({ modals: { ...CLOSED_MODALS, habit: true }, editingTask: task, habitEditMode: 'series' }),
   openSearchModal: () =>
     set({ modals: { ...CLOSED_MODALS, search: true } }),
   openFocusModal: () =>
@@ -212,7 +222,7 @@ export const useUIStore = create<UIState>((set, get) => ({
   openWorkspaceModal: () =>
     set({ modals: { ...CLOSED_MODALS, workspace: true } }),
   closeAllModals: () =>
-    set({ modals: { ...CLOSED_MODALS }, editingTask: null }),
+    set({ modals: { ...CLOSED_MODALS }, editingTask: null, habitEditMode: null }),
 
   // ── Selection ──
   toggleTaskSelect: (id) => {


### PR DESCRIPTION
Introduces a full habit (repeating task) system with dedicated UI,
edit modes, and statistics separation.

Core habit engine (tasksStore):
- New Task fields: isHabit, templateId, startDate, repeatEndDate
- generateRepeatDates() — creates daily/weekly/monthly instances
  within a rolling 30-day window (or until repeatEndDate)
- addTaskRich() creates a root task + all instances atomically
- ensureHabitInstances() — auto-fills future instances on app load
- deleteHabitInstances() — supports 'this' / 'future' / 'all' modes
- getHabitGroups() — aggregates instances into HabitGroup objects
  (completionRate, totalCount, completedCount, overdueCount)
- getDeletedTasks() excludes habit instances from trash history

UI — HabitModal (new file):
- Three-mode modal: create / edit occurrence / edit series
- Create: full form (title, repeat, priority, dates, workspace, category)
- Edit occurrence: title locked (read-only), notes editable per-instance,
  description shown as read-only series reference
- Edit series: title, description, priority, workspace, category
  propagated via Promise.all to all non-deleted instances;
  repeat & dates locked with info banner

UI — TaskList / HabitGroupItem:
- Dedicated Habits view with one card per series
- Collapsible group card: progress bar, completion %, overdue badge,
  date range, edit-series button, delete-all (with confirm)
- Habit/task filter chips in mixed views (Today, This Week, etc.)
- Header count shows number of habit series, not instances

UI — TaskItem:
- Fix: complete animation (opacity fade) now resets for habit instances
  after markAsCompleted so the completed state renders correctly
- HabitDeleteDialog: three-option delete (this / future / all)
- Edit button routes to openHabitModal (occurrence mode)

Sidebar:
- Add Habit button → opens HabitModal in create mode
- Habits nav item with route to habits view
- Removed habitsCount badge (count now shown in view header)

Statistics:
- Habit instances excluded from all chart data, KPI cards, pie chart
  and priority breakdown to avoid inflating task metrics
- Plan for dedicated habit statistics added to docs/spec-docs/

uiStore:
- habitEditMode: 'instance' | 'series' | null
- openHabitSeriesModal() action
- openHabitModal() sets habitEditMode based on whether task is passed